### PR TITLE
Hotfix/update config file structure

### DIFF
--- a/conf/sections.go
+++ b/conf/sections.go
@@ -89,6 +89,5 @@ type Auth struct {
 }
 
 type ImpressionListener struct {
-	Enabled  bool   `json:"enabled" split-default-value:"false" split-cli-option:"impression-listener" split-cli-description:"Enable posting impressions to an user specified endpoint"`
 	Endpoint string `json:"endpoint" split-default-value:"" split-cli-option:"impression-listener-endpoint" split-cli-description:"HTTP endpoint where impression bulks will be posted"`
 }

--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func init() {
 func startAsProxy() {
 	go task.FetchRawSplits(conf.Data.SplitsFetchRate, conf.Data.SegmentFetchRate)
 
-	if conf.Data.ImpressionListener.Enabled {
+	if conf.Data.ImpressionListener.Endpoint != "" {
 		go task.PostImpressionsToListener(recorder.ImpressionListenerSubmitter{
 			Endpoint: conf.Data.ImpressionListener.Endpoint,
 		})
@@ -95,7 +95,7 @@ func startAsProxy() {
 		AdminUsername:             conf.Data.Proxy.AdminUsername,
 		AdminPassword:             conf.Data.Proxy.AdminPassword,
 		DebugOn:                   conf.Data.Logger.DebugOn,
-		ImpressionListenerEnabled: conf.Data.ImpressionListener.Enabled,
+		ImpressionListenerEnabled: conf.Data.ImpressionListener.Endpoint != "",
 	}
 
 	//Run webserver loop
@@ -230,7 +230,7 @@ func startProducer() {
 	for i := 0; i < conf.Data.ImpressionsThreads; i++ {
 		impressionsStorage := redis.NewImpressionStorageAdapter(redis.Client, conf.Data.Redis.Prefix)
 		impressionsRecorder := recorder.ImpressionsHTTPRecorder{}
-		if conf.Data.ImpressionListener.Enabled {
+		if conf.Data.ImpressionListener.Endpoint != "" {
 			go task.PostImpressionsToListener(recorder.ImpressionListenerSubmitter{
 				Endpoint: conf.Data.ImpressionListener.Endpoint,
 			})
@@ -240,7 +240,7 @@ func startProducer() {
 			impressionsRecorder,
 			impressionsStorage,
 			conf.Data.ImpressionsPostRate,
-			conf.Data.ImpressionListener.Enabled,
+			conf.Data.ImpressionListener.Endpoint != "",
 		)
 
 	}

--- a/splitio/version.go
+++ b/splitio/version.go
@@ -2,4 +2,4 @@
 package splitio
 
 // Version is the version of this Agent
-const Version = "1.2.0"
+const Version = "1.2.1-rc1"


### PR DESCRIPTION
Simple change to simplify config structure:
"Enabled": true is no longer used.
Impression listener is enabled if the endpoint is set to something other than an empty string.