### PR TITLE
Fix/impressions retrieval quota

### DIFF
--- a/conf/sections.go
+++ b/conf/sections.go
@@ -64,8 +64,8 @@ type ConfigData struct {
 	ImpressionListener     ImpressionListener `json:"impressionListener" split-cli-option-group:"true"`
 	SplitsFetchRate        int                `json:"splitsRefreshRate" split-cli-option:"split-refresh-rate" split-default-value:"60" split-cli-description:"Refresh rate of splits fetcher"`
 	SegmentFetchRate       int                `json:"segmentsRefreshRate" split-default-value:"60" split-cli-option:"segment-refresh-rate" split-cli-description:"Refresh rate of segments fetcher"`
-	ImpressionsPostRate    int                `json:"impressionsRefreshRate" split-default-value:"60" split-cli-option:"impressions-post-rate" split-cli-description:"Post rate of impressions recorder"`
-	ImpressionsPerPost     int64              `json:"impressionsPerPost" split-cli-option:"impressions-per-post" split-default-value:"1000" split-cli-description:"Number of impressions to send in a POST request"`
+	ImpressionsPostRate    int                `json:"impressionsRefreshRate" split-default-value:"20" split-cli-option:"impressions-post-rate" split-cli-description:"Post rate of impressions recorder"`
+	ImpressionsPerPost     int64              `json:"impressionsPerPost" split-cli-option:"impressions-per-post" split-default-value:"50000" split-cli-description:"Number of impressions to send in a POST request"`
 	ImpressionsThreads     int                `json:"impressionsThreads" split-default-value:"1" split-cli-option:"impressions-recorder-threads" split-cli-description:"Number of impressions recorder threads"`
 	EventsPushRate         int                `json:"eventsPushRate" split-default-value:"60" split-cli-option:"events-push-rate" split-cli-description:"Post rate of event recorder (seconds)"`
 	EventsConsumerReadSize int                `json:"eventsConsumerReadSize" split-default-value:"10000" split-cli-option:"events-consumer-read-size" split-cli-description:"Events queue read size"`

--- a/splitio/storage/redis/impression.go
+++ b/splitio/storage/redis/impression.go
@@ -116,32 +116,32 @@ func (r ImpressionStorageAdapter) getImpressionsWithoutCardinality() ([]string, 
 	return _keys, nil
 }
 
-func parseImpressionKey(key string) (*string, *string, *string, error) {
+func parseImpressionKey(key string) (string, string, string, error) {
 	var re = regexp.MustCompile(`(\w+.)?SPLITIO\/([^\/]+)\/([^\/]+)\/impressions.([\s\S]*)`)
 	match := re.FindStringSubmatch(key)
 
 	if len(match) < 5 {
-		return nil, nil, nil, fmt.Errorf("Error parsing key %s", key)
+		return "", "", "", fmt.Errorf("Error parsing key %s", key)
 	}
 
 	sdkNameAndVersion := match[2]
 	if sdkNameAndVersion == "" {
-		return nil, nil, nil, fmt.Errorf("Invalid sdk name/version")
+		return "", "", "", fmt.Errorf("Invalid sdk name/version")
 	}
 
 	machineIP := match[3]
 	if machineIP == "" {
-		return nil, nil, nil, fmt.Errorf("Invalid machine IP")
+		return "", "", "", fmt.Errorf("Invalid machine IP")
 	}
 
 	featureName := match[4]
 	if featureName == "" {
-		return nil, nil, nil, fmt.Errorf("Invalid feature name")
+		return "", "", "", fmt.Errorf("Invalid feature name")
 	}
 
 	log.Verbose.Println("Impression parsed key", match)
 
-	return &sdkNameAndVersion, &machineIP, &featureName, nil
+	return sdkNameAndVersion, machineIP, featureName, nil
 }
 
 func parseRawImpressions(impressions []string) []api.ImpressionDTO {
@@ -235,13 +235,13 @@ func (r ImpressionStorageAdapter) RetrieveImpressions() (map[string]map[string][
 			continue
 		}
 
-		if _, ok := impressionsToReturn[*sdkNameAndVersion][*machineIP]; !ok {
-			impressionsToReturn[*sdkNameAndVersion] = make(map[string][]api.ImpressionsDTO)
+		if _, ok := impressionsToReturn[sdkNameAndVersion][machineIP]; !ok {
+			impressionsToReturn[sdkNameAndVersion] = make(map[string][]api.ImpressionsDTO)
 		}
 
-		impressionsToReturn[*sdkNameAndVersion][*machineIP] = append(
-			impressionsToReturn[*sdkNameAndVersion][*machineIP],
-			api.ImpressionsDTO{TestName: *featureName, KeyImpressions: _keyImpressions},
+		impressionsToReturn[sdkNameAndVersion][machineIP] = append(
+			impressionsToReturn[sdkNameAndVersion][machineIP],
+			api.ImpressionsDTO{TestName: featureName, KeyImpressions: _keyImpressions},
 		)
 
 		err = r.removeImpressions(impressions, feature)

--- a/splitio/storage/redis/impression.go
+++ b/splitio/storage/redis/impression.go
@@ -2,14 +2,68 @@ package redis
 
 import (
 	"encoding/json"
+	"math"
 	"regexp"
+	"sort"
+	"strings"
 	"time"
 
+	"fmt"
 	"github.com/splitio/split-synchronizer/conf"
 	"github.com/splitio/split-synchronizer/log"
 	"github.com/splitio/split-synchronizer/splitio/api"
 	redis "gopkg.in/redis.v5"
 )
+
+var impressionKeysWithCardinalityScriptTemplate = `
+	local impkeys = redis.call('KEYS', '{KEY_NAMESPACE}')
+	local featureCardinality = {}
+	for i, key in ipairs(impkeys) do
+	    featureCardinality[2 * i - 1] = key
+		featureCardinality[2 * i ] =  redis.call('SCARD', key)
+	end
+	return featureCardinality`
+
+/*
+Private types and functions to handle list of pairs (impressionKey, #impressions), that also implements the required
+interface to enable sorting as well as conversion methods.
+*/
+
+type impressionCardinalityPair struct {
+	key   string
+	value int64
+}
+
+type impressionCardinalityPairList []impressionCardinalityPair
+
+func (l impressionCardinalityPairList) Len() int           { return len(l) }
+func (l impressionCardinalityPairList) Less(i, j int) bool { return l[i].value < l[j].value }
+func (l impressionCardinalityPairList) Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
+func (l impressionCardinalityPairList) ToKeySlice() []string {
+	res := make([]string, 0)
+	for _, item := range l {
+		res = append(res, item.key)
+	}
+	return res
+}
+
+func makeImpressionCardinalityPairList(data []interface{}) (*impressionCardinalityPairList, error) {
+	output := make(impressionCardinalityPairList, 0)
+	for i := 0; i < len(data); i += 2 {
+		key, okKey := data[i].(string)
+		if !okKey {
+			return nil, fmt.Errorf("Error casting %v to string, it's %T", data[i], data[i])
+		}
+		value, okValue := data[i+1].(int64)
+		if !okValue {
+			return nil, fmt.Errorf("Error casting %v to int, it's %T", data[i+1], data[i+1])
+		}
+		output = append(output, impressionCardinalityPair{key, value})
+	}
+	return &output, nil
+}
+
+/* */
 
 // ImpressionStorageAdapter implements ImpressionStorage interface
 type ImpressionStorageAdapter struct {
@@ -24,30 +78,128 @@ func NewImpressionStorageAdapter(clientInstance *redis.Client, prefix string) *I
 	return &client
 }
 
-// RetrieveImpressions returns cached impressions
-func (r ImpressionStorageAdapter) RetrieveImpressions() (map[string]map[string][]api.ImpressionsDTO, error) {
+func (r ImpressionStorageAdapter) getImpressionsWithCardinality() (*impressionCardinalityPairList, error) {
+	script := strings.Replace(
+		impressionKeysWithCardinalityScriptTemplate, "{KEY_NAMESPACE}",
+		r.impressionsNamespace("*", "*", "*"),
+		1,
+	)
 
+	result, err := Client.Eval(script, nil, 0).Result()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to execute LUA script: %v", err.Error())
+	}
+
+	resultList, convOk := result.([]interface{})
+	if !convOk {
+		return nil, fmt.Errorf("Failed to type-assert script's output. %T", resultList)
+	}
+
+	impressionsWithCard, err := makeImpressionCardinalityPairList(resultList)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to type-assert returned structure: %s", err.Error())
+	}
+
+	sort.Sort(impressionsWithCard)
+	return impressionsWithCard, nil
+}
+
+func (r ImpressionStorageAdapter) getImpressionsWithoutCardinality() ([]string, error) {
 	_keys, err := r.client.Keys(r.impressionsNamespace("*", "*", "*")).Result()
 	if err == redis.Nil {
 		log.Debug.Println("Fetching impression Keys", err.Error())
-		return nil, nil
+		return nil, err
 	} else if err != nil {
 		log.Error.Println(err.Error())
 		return nil, err
 	}
+	return _keys, nil
+}
+
+func parseImpressionKey(key string) (*string, *string, *string, error) {
+	var re = regexp.MustCompile(`(\w+.)?SPLITIO\/([^\/]+)\/([^\/]+)\/impressions.([\s\S]*)`)
+	match := re.FindStringSubmatch(key)
+
+	if len(match) < 5 {
+		return nil, nil, nil, fmt.Errorf("Error parsing key %s", key)
+	}
+
+	sdkNameAndVersion := match[2]
+	if sdkNameAndVersion == "" {
+		return nil, nil, nil, fmt.Errorf("Invalid sdk name/version")
+	}
+
+	machineIP := match[3]
+	if machineIP == "" {
+		return nil, nil, nil, fmt.Errorf("Invalid machine IP")
+	}
+
+	featureName := match[4]
+	if featureName == "" {
+		return nil, nil, nil, fmt.Errorf("Invalid feature name")
+	}
+
+	log.Verbose.Println("Impression parsed key", match)
+
+	return &sdkNameAndVersion, &machineIP, &featureName, nil
+}
+
+func parseRawImpressions(impressions []string) []api.ImpressionDTO {
+	_keyImpressions := make([]api.ImpressionDTO, 0)
+	for _, impression := range impressions {
+		var impressionDTO api.ImpressionDTO
+		err := json.Unmarshal([]byte(impression), &impressionDTO)
+		if err != nil {
+			log.Warning.Println("The impression cannot be decoded from JSON", err.Error())
+			log.Verbose.Println("Impression value:", impression)
+			continue
+		}
+		_keyImpressions = append(_keyImpressions, impressionDTO)
+	}
+	return _keyImpressions
+}
+
+func (r ImpressionStorageAdapter) removeImpressions(impressions []string, feature string) error {
+	_impressionsToDelete := make([]interface{}, len(impressions))
+	for i, v := range impressions {
+		_impressionsToDelete[i] = v
+	}
+
+	beforeSRem := time.Now().UnixNano()
+	if err := r.client.SRem(feature, _impressionsToDelete...).Err(); err != nil {
+		return err
+	}
+	log.Benchmark.Println("Srem took", (time.Now().UnixNano() - beforeSRem))
+	return nil
+}
+
+// RetrieveImpressions returns cached impressions
+func (r ImpressionStorageAdapter) RetrieveImpressions() (map[string]map[string][]api.ImpressionsDTO, error) {
+
+	var _keys []string
+	// Attempt to fetch imressione keys using a LUA script to get both keys and number.
+	// This will enable to sort features by # of impressions and use a greedy approach to
+	// fetch as much impressions as possible.
+	impressionsWithCard, err := r.getImpressionsWithCardinality()
+	if err == nil {
+		_keys = impressionsWithCard.ToKeySlice()
+		// TODO: Use cardinality for reporting impression usage as well
+	} else {
+		// Something went wrong when trying to fetch using LUA script, fallback to simple method.
+		_keys, err = r.getImpressionsWithoutCardinality()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	impressionsToReturn := make(map[string]map[string][]api.ImpressionsDTO)
 
-	/*TODO see the edge case:
-	impressionsPerPost < len(keys)
-	*/
 	log.Benchmark.Println("Impressions per post", conf.Data.ImpressionsPerPost)
 	var impressionsPerKey = conf.Data.ImpressionsPerPost
+
+	// At least one impression per feature
 	if len(_keys) > 0 && impressionsPerKey >= int64(len(_keys)) {
-		impressionsPerKey = conf.Data.ImpressionsPerPost / int64(len(_keys))
-	} else if impressionsPerKey < int64(len(_keys)) {
-		// TODO add extra logic when impressionsPerKey is les than Key number in Redis
-		impressionsPerKey = 1
+		impressionsPerKey = int64(math.Max(float64(conf.Data.ImpressionsPerPost/int64(len(_keys))), float64(1)))
 	}
 
 	log.Benchmark.Println("Number of Keys", len(_keys))
@@ -57,61 +209,46 @@ func (r ImpressionStorageAdapter) RetrieveImpressions() (map[string]map[string][
 	// that have less impressions than `impressionsPerKey`. In order to use those slots
 	// for other features.
 	var extraQuota int64
-	for _, key := range _keys {
-		log.Benchmark.Println("---", key)
+	for _, feature := range _keys {
+		log.Benchmark.Println("---", feature)
 		beforeSRandMemberN := time.Now().UnixNano()
-		impressions, err := r.client.SRandMemberN(key, impressionsPerKey+extraQuota).Result()
+		impressions, err := r.client.SRandMemberN(feature, impressionsPerKey+extraQuota).Result()
 		log.Benchmark.Println("SRandMemberN took", (time.Now().UnixNano() - beforeSRandMemberN))
 		log.Verbose.Println(impressions)
 		if err != nil {
-			log.Debug.Println("Fetching impressions", err.Error())
+			log.Error.Printf("Error fetching impressions from key %s. %s", feature, err.Error())
 			continue
 		}
-		extraQuota = (impressionsPerKey + extraQuota) - int64(len(impressions))
 		if len(impressions) == 0 {
-			log.Debug.Println("Not found impressions for this key", key)
+			log.Debug.Println("No impressions found for feature ", feature)
 			continue
 		}
 
-		var _keyImpressions []api.ImpressionDTO
-		for _, impression := range impressions {
-			var impressionDTO api.ImpressionDTO
-			err = json.Unmarshal([]byte(impression), &impressionDTO)
-			if err != nil {
-				log.Warning.Println("The impression cannot be decoded from JSON", err.Error())
-				log.Verbose.Println("Impression value:", impression)
-				continue
-			}
-			_keyImpressions = append(_keyImpressions, impressionDTO)
+		extraQuota = (impressionsPerKey + extraQuota) - int64(len(impressions))
+
+		_keyImpressions := parseRawImpressions(impressions)
+
+		sdkNameAndVersion, machineIP, featureName, err := parseImpressionKey(feature)
+		if err != nil {
+			log.Error.Printf("Unable to parse key %s. Removing", feature)
+			r.client.Del(feature)
+			continue
 		}
 
-		//(\w+.)?SPLITIO\/([^\/]+)\/([^\/]+)\/impressions.([\s\S]*)
-		var re = regexp.MustCompile(`(\w+.)?SPLITIO\/([^\/]+)\/([^\/]+)\/impressions.([\s\S]*)`)
-		match := re.FindStringSubmatch(key)
-
-		sdkNameAndVersion := match[2]
-		machineIP := match[3]
-		featureName := match[4]
-
-		log.Verbose.Println("Impression parsed key", match)
-
-		if _, ok := impressionsToReturn[sdkNameAndVersion][machineIP]; !ok {
-			impressionsToReturn[sdkNameAndVersion] = make(map[string][]api.ImpressionsDTO)
+		if _, ok := impressionsToReturn[*sdkNameAndVersion][*machineIP]; !ok {
+			impressionsToReturn[*sdkNameAndVersion] = make(map[string][]api.ImpressionsDTO)
 		}
-		impressionsToReturn[sdkNameAndVersion][machineIP] = append(impressionsToReturn[sdkNameAndVersion][machineIP], api.ImpressionsDTO{TestName: featureName, KeyImpressions: _keyImpressions})
 
-		//DELETE impressions
-		_impressionsToDelete := make([]interface{}, len(impressions))
-		for i, v := range impressions {
-			_impressionsToDelete[i] = v
-		}
-		beforeSRem := time.Now().UnixNano()
-		if err := r.client.SRem(key, _impressionsToDelete...).Err(); err != nil {
+		impressionsToReturn[*sdkNameAndVersion][*machineIP] = append(
+			impressionsToReturn[*sdkNameAndVersion][*machineIP],
+			api.ImpressionsDTO{TestName: *featureName, KeyImpressions: _keyImpressions},
+		)
+
+		err = r.removeImpressions(impressions, feature)
+		if err != nil {
 			log.Error.Println("Error removing impressions from Redis", err.Error())
 			log.Verbose.Println(impressions)
 		}
-		log.Benchmark.Println("Srem took", (time.Now().UnixNano() - beforeSRem))
 	}
-
 	return impressionsToReturn, nil
 }

--- a/splitio/storage/redis/impression_test.go
+++ b/splitio/storage/redis/impression_test.go
@@ -382,14 +382,14 @@ func TestThatMalformedImpressionKeysDoNotPanic(t *testing.T) {
 		if err == nil {
 			t.Error("An error should have been returned.")
 		}
-		if sdk != nil {
-			t.Errorf("Sdk should be nil. Is %s", *sdk)
+		if sdk != "" {
+			t.Errorf("Sdk should be empty. Is %s", sdk)
 		}
-		if ip != nil {
-			t.Errorf("Ip should be nil. Is %s", *ip)
+		if ip != "" {
+			t.Errorf("Ip should be empty. Is %s", ip)
 		}
-		if feature != nil {
-			t.Errorf("Feature should be nil. Is %s", *feature)
+		if feature != "" {
+			t.Errorf("Feature should be empty. Is %s", feature)
 		}
 	}
 }

--- a/splitio/storage/redis/impression_test.go
+++ b/splitio/storage/redis/impression_test.go
@@ -263,7 +263,7 @@ func TestLuaScriptFailure(t *testing.T) {
 
 	if !strings.Contains(
 		err.Error(),
-		"Failed to execute LUA script: ERR Error compiling script (new function): user_script:1: unfinished string near ''{KEY_NAME'",
+		"Failed to execute LUA script: ERR Error compiling script ",
 	) {
 		t.Error("Incorrect error cause")
 		t.Error(err.Error())

--- a/splitio/storage/redis/impression_test.go
+++ b/splitio/storage/redis/impression_test.go
@@ -2,8 +2,10 @@
 package redis
 
 import (
-	"errors"
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
+	"strings"
 	"testing"
 
 	"github.com/splitio/split-synchronizer/conf"
@@ -13,16 +15,16 @@ import (
 
 func findImpressionsForFeature(
 	bulk map[string]map[string][]api.ImpressionsDTO,
-	featureName string,
-	instanceID string,
 	sdk string,
+	instanceID string,
+	featureName string,
 ) (*api.ImpressionsDTO, error) {
 	for _, feature := range bulk[sdk][instanceID] {
 		if feature.TestName == featureName {
 			return &feature, nil
 		}
 	}
-	return nil, errors.New("featre not found")
+	return nil, fmt.Errorf("Feature %s not found", featureName)
 }
 
 func TestImpressionStorageAdapter(t *testing.T) {
@@ -36,7 +38,6 @@ func TestImpressionStorageAdapter(t *testing.T) {
 	languageAndVersion := "test-2.0"
 	instanceID := "127.0.0.1"
 	featureName := "some_feature"
-
 	impressionTXT1 := `{"keyName":"some_key1","treatment":"off","time":1234567890,"changeNumber":55555555,"label":"some label","bucketingKey":"some_bucket_key"}`
 	impressionTXT2 := `{"keyName":"some_key2","treatment":"on","time":1234567999,"changeNumber":577775,"label":"some label no match","bucketingKey":"some_bucket_key_2"}`
 
@@ -71,7 +72,6 @@ func TestImpressionStorageAdapter(t *testing.T) {
 	if len(impressionDTO.KeyImpressions) != 2 {
 		t.Error("Error counting fetched impressions")
 	}
-
 }
 
 func TestThatQuotaiIsApplied(t *testing.T) {
@@ -84,7 +84,6 @@ func TestThatQuotaiIsApplied(t *testing.T) {
 
 	languageAndVersion := "test-2.0"
 	instanceID := "127.0.0.1"
-	featureName := "some_feature"
 
 	impressionsRaw := map[string][]api.ImpressionDTO{
 		"feature1": {
@@ -127,6 +126,14 @@ func TestThatQuotaiIsApplied(t *testing.T) {
 				Label:        "label1",
 				Time:         123,
 				Treatment:    "treatment5",
+			},
+			{
+				BucketingKey: "",
+				ChangeNumber: 0,
+				KeyName:      "key6",
+				Label:        "label1",
+				Time:         123,
+				Treatment:    "treatment6",
 			},
 		},
 		"feature2": {
@@ -184,17 +191,16 @@ func TestThatQuotaiIsApplied(t *testing.T) {
 	}
 
 	prefixAdapter := &prefixAdapter{prefix: ""}
-
 	//Adding impressions to retrieve.
 	for feature, impressions := range impressionsRaw {
 		for _, impression := range impressions {
+			toStore, _ := json.Marshal(impression)
 			Client.SAdd(
-				prefixAdapter.impressionsNamespace(languageAndVersion, instanceID, featureName),
-				impression,
+				prefixAdapter.impressionsNamespace(languageAndVersion, instanceID, feature),
+				toStore,
 			)
 		}
 	}
-
 	conf.Data.ImpressionsPerPost = 9
 	impressionsStorageAdapter := NewImpressionStorageAdapter(Client, "")
 	retrievedImpressions, err := impressionsStorageAdapter.RetrieveImpressions()
@@ -205,19 +211,185 @@ func TestThatQuotaiIsApplied(t *testing.T) {
 
 	// We set an impressionsPerPost value of 6. Which means that when distributed evenly, we should get 3 impressions
 	// per feature. Since feature 2 has only one, we should get 3 for feature1, 1 for feature2 and 5 for feature3.
-	feature1Impressions, _ := findImpressionsForFeature(retrievedImpressions, languageAndVersion, instanceID, "feature1")
+	feature1Impressions, err := findImpressionsForFeature(retrievedImpressions, languageAndVersion, instanceID, "feature1")
+	if err != nil {
+		t.Error(err.Error())
+		return
+	}
 	if len(feature1Impressions.KeyImpressions) != 3 {
-		t.Error("We should have 3 impressions for feature 1")
+		t.Errorf("We should have 3 impressions for feature1, we have %d", len(feature1Impressions.KeyImpressions))
 	}
 
 	feature2Impressions, _ := findImpressionsForFeature(retrievedImpressions, languageAndVersion, instanceID, "feature2")
-	if len(feature2Impressions.KeyImpressions) != 2 {
-		t.Error("We should have 1 impressions for feature 2")
+	if err != nil {
+		t.Error(err.Error())
+		return
+	}
+	if len(feature2Impressions.KeyImpressions) != 1 {
+		t.Errorf("We should have 3 impressions for feature2, we have %d", len(feature2Impressions.KeyImpressions))
 	}
 
 	feature3Impressions, _ := findImpressionsForFeature(retrievedImpressions, languageAndVersion, instanceID, "feature3")
+	if err != nil {
+		t.Error(err.Error())
+		return
+	}
 	if len(feature3Impressions.KeyImpressions) != 5 {
-		t.Error("We should have 5 impressions for feature 3")
+		t.Errorf("We should have 5 impressions for feature3, we have %d", len(feature3Impressions.KeyImpressions))
+	}
+}
+
+func TestLuaScriptFailure(t *testing.T) {
+	stdoutWriter := ioutil.Discard //os.Stdout
+	log.Initialize(stdoutWriter, stdoutWriter, stdoutWriter, stdoutWriter, stdoutWriter, stdoutWriter)
+
+	//Initialize by default
+	conf.Initialize()
+	Initialize(conf.Data.Redis)
+
+	impressionKeysWithCardinalityScriptTemplate = `local impkeys = redis.call('KEYS', '{KEY_NAME`
+
+	impressionsStorageAdapter := NewImpressionStorageAdapter(Client, "")
+	imps, err := impressionsStorageAdapter.getImpressionsWithCardinality()
+	if imps != nil {
+		t.Error("Resulting impressions should be nil")
+		return
 	}
 
+	if err == nil {
+		t.Error("Should have failed")
+		return
+	}
+
+	if !strings.Contains(
+		err.Error(),
+		"Failed to execute LUA script: ERR Error compiling script (new function): user_script:1: unfinished string near ''{KEY_NAME'",
+	) {
+		t.Error("Incorrect error cause")
+		t.Error(err.Error())
+		return
+	}
+
+	imps2, err := impressionsStorageAdapter.RetrieveImpressions()
+	if imps2 == nil {
+		t.Error("Impressions should not be null, fallback should work correctly")
+		return
+	}
+
+	if err != nil {
+		t.Error("No error should have been generated. fallback should work correctly")
+		return
+	}
+}
+
+func TestLuaScriptReturnsIncorrectType(t *testing.T) {
+	stdoutWriter := ioutil.Discard //os.Stdout
+	log.Initialize(stdoutWriter, stdoutWriter, stdoutWriter, stdoutWriter, stdoutWriter, stdoutWriter)
+
+	//Initialize by default
+	conf.Initialize()
+	Initialize(conf.Data.Redis)
+
+	impressionKeysWithCardinalityScriptTemplate = `return 1`
+
+	impressionsStorageAdapter := NewImpressionStorageAdapter(Client, "")
+	imps, err := impressionsStorageAdapter.getImpressionsWithCardinality()
+	if imps != nil {
+		t.Error("Resulting impressions should be nil")
+		return
+	}
+
+	if err == nil {
+		t.Error("Should have failed")
+		return
+	}
+
+	if !strings.Contains(
+		err.Error(),
+		"Failed to type-assert script's output. []interface {}",
+	) {
+		t.Error("Incorrect error cause")
+		t.Error(err.Error())
+		return
+	}
+
+	imps2, err := impressionsStorageAdapter.RetrieveImpressions()
+	if imps2 == nil {
+		t.Error("Impressions should not be null, fallback should work correctly")
+		return
+	}
+
+	if err != nil {
+		t.Error("No error should have been generated. fallback should work correctly")
+		return
+	}
+}
+
+func TestLuaScriptReturnsIncorrectSlice(t *testing.T) {
+	stdoutWriter := ioutil.Discard //os.Stdout
+	log.Initialize(stdoutWriter, stdoutWriter, stdoutWriter, stdoutWriter, stdoutWriter, stdoutWriter)
+
+	//Initialize by default
+	conf.Initialize()
+	Initialize(conf.Data.Redis)
+
+	impressionKeysWithCardinalityScriptTemplate = `return {1, 2, 3}`
+
+	impressionsStorageAdapter := NewImpressionStorageAdapter(Client, "")
+	imps, err := impressionsStorageAdapter.getImpressionsWithCardinality()
+	if imps != nil {
+		t.Error("Resulting impressions should be nil")
+		return
+	}
+
+	if err == nil {
+		t.Error("Should have failed")
+		return
+	}
+
+	if !strings.Contains(
+		err.Error(),
+		"Failed to type-assert returned structure: Error casting 1 to string, it's int64",
+	) {
+		t.Error("Incorrect error cause")
+		t.Error(err.Error())
+		return
+	}
+
+	imps2, err := impressionsStorageAdapter.RetrieveImpressions()
+	if imps2 == nil {
+		t.Error("Impressions should not be null, fallback should work correctly")
+		return
+	}
+
+	if err != nil {
+		t.Error("No error should have been generated. fallback should work correctly")
+		return
+	}
+}
+
+func TestThatMalformedImpressionKeysDoNotPanic(t *testing.T) {
+	wrongKeys := []string{
+		"SPLITIO/php-5.3.1//impressions.mono_signal_unique_payers_for_payee",
+		"SPLITIO/php-5.3.1///impressions.mono_signal_unique_payers_for_payee",
+		"SPLITIO//ip-123-123-123-123/impressions.mono_signal_unique_payers_for_payee",
+		"SPLITIO///impressions.mono_signal_unique_payers_for_payee",
+		"SPLITIO///ip-123-123-123-123//php-5.3.1//impressions.mono_signal_unique_payers_for_payee",
+	}
+
+	for _, key := range wrongKeys {
+		sdk, ip, feature, err := parseImpressionKey(key)
+		if err == nil {
+			t.Error("An error should have been returned.")
+		}
+		if sdk != nil {
+			t.Errorf("Sdk should be nil. Is %s", *sdk)
+		}
+		if ip != nil {
+			t.Errorf("Ip should be nil. Is %s", *ip)
+		}
+		if feature != nil {
+			t.Errorf("Feature should be nil. Is %s", *feature)
+		}
+	}
 }

--- a/splitio/storage/redis/metrics_test.go
+++ b/splitio/storage/redis/metrics_test.go
@@ -121,17 +121,17 @@ func TestThatMalformedLatencyKeysDoNotPanic(t *testing.T) {
 		if err == nil {
 			t.Error("An error should have been returned.")
 		}
-		if sdk != nil {
-			t.Errorf("Sdk should be nil. Is %s", *sdk)
+		if sdk != "" {
+			t.Errorf("Sdk should be nil. Is %s", sdk)
 		}
-		if ip != nil {
-			t.Errorf("Ip should be nil. Is %s", *ip)
+		if ip != "" {
+			t.Errorf("Ip should be nil. Is %s", ip)
 		}
-		if feature != nil {
-			t.Errorf("Feature should be nil. Is %s", *feature)
+		if feature != "" {
+			t.Errorf("Feature should be nil. Is %s", feature)
 		}
-		if bucket != nil {
-			t.Errorf("Bucket should be nil. Is %d", *bucket)
+		if bucket != 0 {
+			t.Errorf("Bucket should be nil. Is %d", bucket)
 		}
 	}
 }
@@ -150,17 +150,17 @@ func TestThatMalformedCounterKeysDoNotPanic(t *testing.T) {
 		if err == nil {
 			t.Error("An error should have been returned.")
 		}
-		if sdk != nil {
-			t.Errorf("Sdk should be nil. Is %s", *sdk)
+		if sdk != "" {
+			t.Errorf("Sdk should be nil. Is %s", sdk)
 		}
-		if ip != nil {
-			t.Errorf("Ip should be nil. Is %s", *ip)
+		if ip != "" {
+			t.Errorf("Ip should be nil. Is %s", ip)
 		}
-		if feature != nil {
-			t.Errorf("Feature should be nil. Is %s", *feature)
+		if feature != "" {
+			t.Errorf("Feature should be nil. Is %s", feature)
 		}
-		if bucket != nil {
-			t.Errorf("Bucket should be nil. Is %d", *bucket)
+		if bucket != 0 {
+			t.Errorf("Bucket should be nil. Is %d", bucket)
 		}
 	}
 }
@@ -179,17 +179,17 @@ func TestThatMalformedGaugeKeysDoNotPanic(t *testing.T) {
 		if err == nil {
 			t.Error("An error should have been returned.")
 		}
-		if sdk != nil {
-			t.Errorf("Sdk should be nil. Is %s", *sdk)
+		if sdk != "" {
+			t.Errorf("Sdk should be nil. Is %s", sdk)
 		}
-		if ip != nil {
-			t.Errorf("Ip should be nil. Is %s", *ip)
+		if ip != "" {
+			t.Errorf("Ip should be nil. Is %s", ip)
 		}
-		if feature != nil {
-			t.Errorf("Feature should be nil. Is %s", *feature)
+		if feature != "" {
+			t.Errorf("Feature should be nil. Is %s", feature)
 		}
-		if bucket != nil {
-			t.Errorf("Bucket should be nil. Is %d", *bucket)
+		if bucket != 0 {
+			t.Errorf("Bucket should be nil. Is %d", bucket)
 		}
 	}
 }

--- a/splitio/storage/redis/metrics_test.go
+++ b/splitio/storage/redis/metrics_test.go
@@ -106,3 +106,90 @@ func TestMetricsRedisStorageAdapter(t *testing.T) {
 	}
 
 }
+
+func TestThatMalformedLatencyKeysDoNotPanic(t *testing.T) {
+	wrongKeys := []string{
+		"SPLITIO/php-5.3.1//latency.sdk.get_treatment.bucket.15",
+		"SPLITIO//123.123.123.123/latency.sdk.get_treatment.bucket.15",
+		"SPLITIO///latency.sdk.get_treatment.bucket.s15",
+		"SPLITIO//////.sdk.get_treatment.bucket.15",
+		"/php-5.3.1/123.123.123.123/latency.sdk.get_treatment.bucket.15",
+	}
+
+	for _, key := range wrongKeys {
+		sdk, ip, feature, bucket, err := parseLatencyKey(key)
+		if err == nil {
+			t.Error("An error should have been returned.")
+		}
+		if sdk != nil {
+			t.Errorf("Sdk should be nil. Is %s", *sdk)
+		}
+		if ip != nil {
+			t.Errorf("Ip should be nil. Is %s", *ip)
+		}
+		if feature != nil {
+			t.Errorf("Feature should be nil. Is %s", *feature)
+		}
+		if bucket != nil {
+			t.Errorf("Bucket should be nil. Is %d", *bucket)
+		}
+	}
+}
+
+func TestThatMalformedCounterKeysDoNotPanic(t *testing.T) {
+	wrongKeys := []string{
+		"SPLITIO/php-5.3.1//count.http_errors",
+		"SPLITIO//123.123.123.123/count.http_errors",
+		"SPLITIO///count.http_errors",
+		"SPLITIO//////count.http_errors",
+		"/php-5.3.1/123.123.123.123/count.http_errors",
+	}
+
+	for _, key := range wrongKeys {
+		sdk, ip, feature, bucket, err := parseLatencyKey(key)
+		if err == nil {
+			t.Error("An error should have been returned.")
+		}
+		if sdk != nil {
+			t.Errorf("Sdk should be nil. Is %s", *sdk)
+		}
+		if ip != nil {
+			t.Errorf("Ip should be nil. Is %s", *ip)
+		}
+		if feature != nil {
+			t.Errorf("Feature should be nil. Is %s", *feature)
+		}
+		if bucket != nil {
+			t.Errorf("Bucket should be nil. Is %d", *bucket)
+		}
+	}
+}
+
+func TestThatMalformedGaugeKeysDoNotPanic(t *testing.T) {
+	wrongKeys := []string{
+		"SPLITIO/php-5.3.1//gauge.storage_fill_percentage",
+		"SPLITIO//123.123.123.123/gauge.storage_fill_percentage",
+		"SPLITIO///gauge.storage_fill_percentage",
+		"SPLITIO//////gauge.storage_fill_percentage",
+		"/php-5.3.1/123.123.123.123/gauge.storage_fill_percentage",
+	}
+
+	for _, key := range wrongKeys {
+		sdk, ip, feature, bucket, err := parseLatencyKey(key)
+		if err == nil {
+			t.Error("An error should have been returned.")
+		}
+		if sdk != nil {
+			t.Errorf("Sdk should be nil. Is %s", *sdk)
+		}
+		if ip != nil {
+			t.Errorf("Ip should be nil. Is %s", *ip)
+		}
+		if feature != nil {
+			t.Errorf("Feature should be nil. Is %s", *feature)
+		}
+		if bucket != nil {
+			t.Errorf("Bucket should be nil. Is %d", *bucket)
+		}
+	}
+}

--- a/splitio/version.go
+++ b/splitio/version.go
@@ -2,4 +2,4 @@
 package splitio
 
 // Version is the version of this Agent
-const Version = "1.7.1"
+const Version = "1.7.2-rc1"


### PR DESCRIPTION
* Fix error when parsing malformed imrpessions & metrics keys
* Update default configuration to send more impressions
* Update impressions retrieval logic to better distribute slots among features
* Add support for collecting impression storage usage counters. (To be used on next iteration)