### PR TITLE
[SDKS-487]: Synchronizer Update featuresRefreshRate to be 5 seconds

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+2.1.1 (March 7, 2019)
+ - Updated Splits refreshing rate.
 2.1.0 (Jan 31, 2019)
  - Added endpoints for flushing and dropping Impressions/Events mannually.
  - Added new metrics on Synchronizer Dashboard in Producer Mode to reflect the queue size of Events and Impressions.

--- a/conf/parser_test.go
+++ b/conf/parser_test.go
@@ -37,7 +37,7 @@ func TestLoadFromFileWithErrorOnSection(t *testing.T) {
 		t.Error("It should inform an error")
 	}
 	if err.Error() != "\"redisError\" is not a valid property in configuration" {
-		t.Error("Wrong message error")
+		t.Error("Wrong message error: actual:", err.Error())
 	}
 }
 
@@ -47,7 +47,7 @@ func TestLoadFromFileWithErrorOnSectionAndChildShouldInformSection(t *testing.T)
 		t.Error("It should inform an error")
 	}
 	if err.Error() != "\"redisError\" is not a valid property in configuration" {
-		t.Error("Wrong message error")
+		t.Error("Wrong message error: actual:", err.Error())
 	}
 }
 
@@ -57,7 +57,7 @@ func TestLoadFromFileWithErrorInsideSection(t *testing.T) {
 		t.Error("It should inform an error")
 	}
 	if err.Error() != "\"redis.hostError\" is not a valid property in configuration" {
-		t.Error("Wrong message error")
+		t.Error("Wrong message error: actual:", err.Error())
 	}
 }
 
@@ -67,7 +67,7 @@ func TestLoadFromFileWithErrorOnPropertyInt(t *testing.T) {
 		t.Error("It should inform an error")
 	}
 	if err.Error() != "\"metricsError\" is not a valid property in configuration" {
-		t.Error("Wrong message error")
+		t.Error("Wrong message error: actual:", err.Error())
 	}
 }
 
@@ -77,7 +77,7 @@ func TestLoadFromFileWithErrorOnPropertyString(t *testing.T) {
 		t.Error("It should inform an error")
 	}
 	if err.Error() != "\"apiKeyError\" is not a valid property in configuration" {
-		t.Error("Wrong message error")
+		t.Error("Wrong message error: actual:", err.Error())
 	}
 }
 

--- a/conf/parser_test.go
+++ b/conf/parser_test.go
@@ -37,7 +37,7 @@ func TestLoadFromFileWithErrorOnSection(t *testing.T) {
 		t.Error("It should inform an error")
 	}
 	if err.Error() != "\"redisError\" is not a valid property in configuration" {
-		t.Error("Wrong message error: actual:", err.Error())
+		t.Error("Wrong message error, actual:", err.Error())
 	}
 }
 
@@ -47,7 +47,7 @@ func TestLoadFromFileWithErrorOnSectionAndChildShouldInformSection(t *testing.T)
 		t.Error("It should inform an error")
 	}
 	if err.Error() != "\"redisError\" is not a valid property in configuration" {
-		t.Error("Wrong message error: actual:", err.Error())
+		t.Error("Wrong message error, actual:", err.Error())
 	}
 }
 
@@ -57,7 +57,7 @@ func TestLoadFromFileWithErrorInsideSection(t *testing.T) {
 		t.Error("It should inform an error")
 	}
 	if err.Error() != "\"redis.hostError\" is not a valid property in configuration" {
-		t.Error("Wrong message error: actual:", err.Error())
+		t.Error("Wrong message error, actual:", err.Error())
 	}
 }
 
@@ -67,7 +67,7 @@ func TestLoadFromFileWithErrorOnPropertyInt(t *testing.T) {
 		t.Error("It should inform an error")
 	}
 	if err.Error() != "\"metricsError\" is not a valid property in configuration" {
-		t.Error("Wrong message error: actual:", err.Error())
+		t.Error("Wrong message error, actual:", err.Error())
 	}
 }
 
@@ -77,7 +77,7 @@ func TestLoadFromFileWithErrorOnPropertyString(t *testing.T) {
 		t.Error("It should inform an error")
 	}
 	if err.Error() != "\"apiKeyError\" is not a valid property in configuration" {
-		t.Error("Wrong message error: actual:", err.Error())
+		t.Error("Wrong message error, actual:", err.Error())
 	}
 }
 

--- a/conf/sections.go
+++ b/conf/sections.go
@@ -68,7 +68,7 @@ type ConfigData struct {
 	Producer               ProducerSection    `json:"sync" split-cli-option-group:"true"`
 	Logger                 LogSection         `json:"log" split-cli-option-group:"true"`
 	ImpressionListener     ImpressionListener `json:"impressionListener" split-cli-option-group:"true"`
-	SplitsFetchRate        int                `json:"splitsRefreshRate" split-cli-option:"split-refresh-rate" split-default-value:"60" split-cli-description:"Refresh rate of splits fetcher"`
+	SplitsFetchRate        int                `json:"splitsRefreshRate" split-cli-option:"split-refresh-rate" split-default-value:"5" split-cli-description:"Refresh rate of splits fetcher"`
 	SegmentFetchRate       int                `json:"segmentsRefreshRate" split-default-value:"60" split-cli-option:"segment-refresh-rate" split-cli-description:"Refresh rate of segments fetcher"`
 	ImpressionsPostRate    int                `json:"impressionsRefreshRate" split-default-value:"20" split-cli-option:"impressions-post-rate" split-cli-description:"Post rate of impressions recorder"`
 	ImpressionsPerPost     int64              `json:"impressionsPerPost" split-cli-option:"impressions-per-post" split-default-value:"50000" split-cli-description:"Number of impressions to send in a POST request"`

--- a/splitio/version.go
+++ b/splitio/version.go
@@ -2,4 +2,4 @@
 package splitio
 
 // Version is the version of this Agent
-const Version = "2.1.0"
+const Version = "2.1.1-rc1"

--- a/test/dataset/test.conf.error5.json
+++ b/test/dataset/test.conf.error5.json
@@ -6,7 +6,7 @@
 	"impressionsRefreshRate":80,
 	"impressionsPerPost":56000,
 	"impressionsThreads": 1,
-	"metricsError":60,
+	"metricsRefreshRate":60,
 
 	"redis": {
     "host":"localhost",


### PR DESCRIPTION
# Synchronizer

## Tickets covered:
* [SDKS-487: Synchronizer Update featuresRefreshRate to be 5 seconds](https://splitio.atlassian.net/browse/SDKS-487)

## What did you accomplish?
* updated refreshing rate for splits

## How to test new changes?
* Run command `go test ./...`
