### PR TITLE
[Synchronizer] Validate Traffic Types used in Track calls

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+2.1.2 ()
+ - Added logic for storing trafficTypeName in redis.
 2.1.1 (March 8, 2019)
  - Updated Splits refreshing rate.
 2.1.0 (Jan 31, 2019)

--- a/splitio/producer/initialization.go
+++ b/splitio/producer/initialization.go
@@ -73,6 +73,10 @@ func segmentStorageFactory() storage.SegmentStorageFactory {
 	return storage.SegmentStorageMainFactory{}
 }
 
+func trafficTypeStorageFactory() storage.TrafficTypeStorage {
+	return redis.NewTrafficTypeStorageAdapter(redis.Client, conf.Data.Redis.Prefix)
+}
+
 func startLoop(loopTime int64) {
 	for {
 		time.Sleep(time.Duration(loopTime) * time.Millisecond)
@@ -93,6 +97,8 @@ func Start(sigs chan os.Signal, gracefulShutdownWaitingGroup *sync.WaitGroup) {
 
 	segmentFetcher := segmentFetcherFactory()
 	segmentStorage := segmentStorageFactory()
+
+	trafficTypeStorage := trafficTypeStorageFactory()
 
 	go func() {
 		// WebAdmin configuration
@@ -123,7 +129,7 @@ func Start(sigs chan os.Signal, gracefulShutdownWaitingGroup *sync.WaitGroup) {
 		waServer.Run()
 	}()
 
-	go task.FetchSplits(splitFetcher, splitStorage, conf.Data.SplitsFetchRate, gracefulShutdownWaitingGroup)
+	go task.FetchSplits(splitFetcher, splitStorage, conf.Data.SplitsFetchRate, gracefulShutdownWaitingGroup, trafficTypeStorage)
 
 	go task.FetchSegments(segmentFetcher, segmentStorage, conf.Data.SegmentFetchRate, gracefulShutdownWaitingGroup)
 

--- a/splitio/storage/interfaces.go
+++ b/splitio/storage/interfaces.go
@@ -61,4 +61,5 @@ type TrafficTypeStorage interface {
 	// Save trafficType
 	Incr(trafficType string) error
 	Decr(trafficType string) error
+	Clean() error
 }

--- a/splitio/storage/interfaces.go
+++ b/splitio/storage/interfaces.go
@@ -55,3 +55,10 @@ type EventStorage interface {
 	//returns the first N elements from events queue
 	PopN(n int64) ([]api.RedisStoredEventDTO, error)
 }
+
+// TrafficTypeStorage interface defines trafficType storage actions
+type TrafficTypeStorage interface {
+	// Save trafficType
+	Incr(trafficType string) error
+	Decr(trafficType string) error
+}

--- a/splitio/storage/redis/events_test.go
+++ b/splitio/storage/redis/events_test.go
@@ -120,6 +120,7 @@ func TestEventsPOPN(t *testing.T) {
 		return
 	}
 
+	adapter.client.Del("splitsyncunittest.SPLITIO.events")
 }
 
 func TestEventsSize(t *testing.T) {

--- a/splitio/storage/redis/metrics_test.go
+++ b/splitio/storage/redis/metrics_test.go
@@ -18,14 +18,14 @@ func TestMetricsRedisStorageAdapter(t *testing.T) {
 	conf.Initialize()
 	Initialize(conf.Data.Redis)
 
-	prefixAdapter := &prefixAdapter{prefix: ""}
+	prefixAdapter := &prefixAdapter{prefix: "metricstest"}
 
 	languageAndVersion := "test-2.0"
 	instanceID := "127.0.0.1"
 	metricName := "some_metric"
 	bucketNumber := "4"
 
-	metricsStorageAdapter := NewMetricsStorageAdapter(Client, "")
+	metricsStorageAdapter := NewMetricsStorageAdapter(Client, "metricstest")
 
 	/* Metric Counters */
 	counterKey := prefixAdapter.metricsCounterNamespace(languageAndVersion, instanceID, metricName)
@@ -105,6 +105,9 @@ func TestMetricsRedisStorageAdapter(t *testing.T) {
 		t.Error("Error retrieving latencie value")
 	}
 
+	metricsStorageAdapter.client.Del("metricstest.SPLITIO/test-2.0/127.0.0.1/gauge.some_metric")
+	metricsStorageAdapter.client.Del("metricstest.SPLITIO/test-2.0/127.0.0.1/latency.some_metric.bucket.4")
+	metricsStorageAdapter.client.Del("metricstest.SPLITIO/test-2.0/127.0.0.1/count.some_metric")
 }
 
 func TestThatMalformedLatencyKeysDoNotPanic(t *testing.T) {

--- a/splitio/storage/redis/namespaces.go
+++ b/splitio/storage/redis/namespaces.go
@@ -34,6 +34,9 @@ const _eventsListNamespace = "SPLITIO.events"
 //Impressions
 const _impressionsQueueNamespace = "SPLITIO.impressions"
 
+//TrafficTypeNames
+const _trafficTypeNamespace = "SPLITIO.trafficType"
+
 type prefixAdapter struct {
 	prefix string
 }
@@ -87,4 +90,8 @@ func (p prefixAdapter) eventsListNamespace() string {
 
 func (p prefixAdapter) impressionsQueueNamespace() string {
 	return fmt.Sprint(p.setPrefixPattern(_impressionsQueueNamespace))
+}
+
+func (p prefixAdapter) trafficTypeNamespace() string {
+	return fmt.Sprintf(p.setPrefixPattern(_trafficTypeNamespace))
 }

--- a/splitio/storage/redis/namespaces_test.go
+++ b/splitio/storage/redis/namespaces_test.go
@@ -76,4 +76,9 @@ func TestNamespaces(t *testing.T) {
 	if splitTillNamespace != "SPLITIO.splits.till" {
 		t.Error("Split till namespace mal-formed")
 	}
+
+	trafficTypeNamespace := prefixAdapter.trafficTypeNamespace()
+	if trafficTypeNamespace != "SPLITIO.trafficType" {
+		t.Error("Traffic Type namespace mal-formed")
+	}
 }

--- a/splitio/storage/redis/segment_test.go
+++ b/splitio/storage/redis/segment_test.go
@@ -13,12 +13,13 @@ func TestSegmentStorageAdapter(t *testing.T) {
 	log.Initialize(stdoutWriter, stdoutWriter, stdoutWriter, stdoutWriter, stdoutWriter, stdoutWriter)
 
 	config := conf.NewInitializedConfigData()
+	config.Redis.Prefix = "segmenttests"
 	Initialize(config.Redis)
 
 	segmentName := "some_segment"
 	var changeNumber int64 = 123123435345
 
-	segmentStorageadapter := NewSegmentStorageAdapter(Client, "")
+	segmentStorageadapter := NewSegmentStorageAdapter(Client, "segmenttests")
 
 	err := segmentStorageadapter.AddToSegment(segmentName, []string{})
 	if err != nil {
@@ -58,4 +59,6 @@ func TestSegmentStorageAdapter(t *testing.T) {
 		t.Error(errRs)
 	}
 
+	segmentStorageadapter.client.Del("segmenttests.SPLITIO.segment.some_segment.till")
+	segmentStorageadapter.client.Del("segmenttests.SPLITIO.segment.some_segment")
 }

--- a/splitio/storage/redis/traffics.go
+++ b/splitio/storage/redis/traffics.go
@@ -1,0 +1,56 @@
+package redis
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/go-redis/redis"
+	"github.com/splitio/split-synchronizer/log"
+)
+
+var trafficMutex sync.Mutex
+
+// TrafficTypeStorageAdapter implements TrafficTypeStorage interface
+type TrafficTypeStorageAdapter struct {
+	*BaseStorageAdapter
+}
+
+// NewTrafficTypeStorageAdapter returns an instance of TrafficTypeStorageAdapter
+func NewTrafficTypeStorageAdapter(clientInstance redis.UniversalClient, prefix string) *TrafficTypeStorageAdapter {
+	prefixAdapter := &prefixAdapter{prefix: prefix}
+	adapter := &BaseStorageAdapter{prefixAdapter, clientInstance}
+	client := TrafficTypeStorageAdapter{BaseStorageAdapter: adapter}
+	return &client
+}
+
+// Incr stores/increments trafficType in Redis
+func (t TrafficTypeStorageAdapter) Incr(trafficType string) error {
+	trafficTypeToIncr := t.trafficTypeNamespace() + "." + trafficType
+
+	err := t.client.Incr(trafficTypeToIncr).Err()
+	if err != nil {
+		log.Error.Println(fmt.Sprintf("Error storing trafficType %s in redis", trafficType))
+		log.Error.Println(err)
+		return errors.New("Error incrementing trafficType")
+	}
+	return nil
+}
+
+// Decr decrements trafficType count in Redis
+func (t TrafficTypeStorageAdapter) Decr(trafficType string) error {
+	defer trafficMutex.Unlock()
+	trafficTypeToDecr := t.trafficTypeNamespace() + "." + trafficType
+
+	trafficMutex.Lock()
+	v, _ := t.client.Get(trafficTypeToDecr).Int()
+	if v > 0 {
+		err := t.client.Decr(trafficTypeToDecr).Err()
+		if err != nil {
+			log.Error.Println(fmt.Sprintf("Error storing trafficType %s in redis", trafficType))
+			log.Error.Println(err)
+			return errors.New("Error decrementing trafficType")
+		}
+	}
+	return nil
+}

--- a/splitio/task/fetchsplits.go
+++ b/splitio/task/fetchsplits.go
@@ -38,6 +38,10 @@ func taskFetchSplits(splitFetcherAdapter fetcher.SplitFetcher,
 		lastChangeNumber = -1
 	}
 
+	if lastChangeNumber == -1 {
+		trafficTypeStorageAdapter.Clean()
+	}
+
 	startTime := splitChangesLatencies.StartMeasuringLatency()
 	data, err := splitFetcherAdapter.Fetch(lastChangeNumber)
 	if err != nil {

--- a/splitio/task/fetchsplits.go
+++ b/splitio/task/fetchsplits.go
@@ -29,7 +29,8 @@ var splitChangesCounters = counter.NewCounter()
 var splitChangesLocalCounters = counter.NewLocalCounter()
 
 func taskFetchSplits(splitFetcherAdapter fetcher.SplitFetcher,
-	splitStorageAdapter storage.SplitStorage) {
+	splitStorageAdapter storage.SplitStorage,
+	trafficTypeStorageAdapter storage.TrafficTypeStorage) {
 
 	lastChangeNumber, err := splitStorageAdapter.ChangeNumber()
 	if err != nil {
@@ -69,9 +70,9 @@ func taskFetchSplits(splitFetcherAdapter fetcher.SplitFetcher,
 				log.Error.Println(err)
 				continue
 			}
-
 			jsonD, _ := rawSplits[i].MarshalJSON()
 			if splitDTO.Status == "ACTIVE" {
+				trafficTypeStorageAdapter.Incr(splitDTO.TrafficTypeName)
 				if err := splitStorageAdapter.Save(jsonD); err == nil {
 					savedItems++
 					totalConditions := len(splitDTO.Conditions)
@@ -91,6 +92,9 @@ func taskFetchSplits(splitFetcherAdapter fetcher.SplitFetcher,
 				if err := splitStorageAdapter.Remove(jsonD); err == nil {
 					deletedItems++
 				}
+				if lastChangeNumber != -1 {
+					trafficTypeStorageAdapter.Decr(splitDTO.TrafficTypeName)
+				}
 			}
 		}
 		log.Debug.Println("Saved splits:", savedItems, "Removed splits:", deletedItems, "of Total items: ", totalItemsRaw)
@@ -100,11 +104,12 @@ func taskFetchSplits(splitFetcherAdapter fetcher.SplitFetcher,
 // FetchSplits task to retrieve split changes from Split servers
 func FetchSplits(splitFetcherAdapter fetcher.SplitFetcher,
 	splitStorageAdapter storage.SplitStorage,
-	splitsRefreshRate int, wg *sync.WaitGroup) {
+	splitsRefreshRate int, wg *sync.WaitGroup,
+	trafficTypeStorageAdapter storage.TrafficTypeStorage) {
 	wg.Add(1)
 	keepLoop := true
 	for keepLoop {
-		taskFetchSplits(splitFetcherAdapter, splitStorageAdapter)
+		taskFetchSplits(splitFetcherAdapter, splitStorageAdapter, trafficTypeStorageAdapter)
 
 		select {
 		case msg := <-splitsIncoming:

--- a/splitio/task/postevents_test.go
+++ b/splitio/task/postevents_test.go
@@ -343,4 +343,6 @@ func TestFlushEventsNilSize(t *testing.T) {
 			t.Error("It should evict 25000 elements. The remaining elements are:", total)
 		}
 	}()
+
+	redis.Client.Del("posteventunittest.SPLITIO.events")
 }

--- a/splitio/task/postimpressions_test.go
+++ b/splitio/task/postimpressions_test.go
@@ -280,4 +280,6 @@ func TestFlushImpressionsInBatches(t *testing.T) {
 			t.Error("It should kept 2 element, but there are:", total)
 		}
 	}()
+
+	redis.Client.Del("postimpressionsintest.SPLITIO.impressions")
 }

--- a/splitio/version.go
+++ b/splitio/version.go
@@ -2,4 +2,4 @@
 package splitio
 
 // Version is the version of this Agent
-const Version = "2.1.1"
+const Version = "2.1.2-rc1"


### PR DESCRIPTION
# Synchronizer

## Tickets covered:
* [SDKS-514:  Validate Traffic Types used in Track calls](https://splitio.atlassian.net/browse/SDKS-514)

## What did you accomplish?
* Added new Storage called `TrafficTypeStorage`
* Added method to `Increment` and `Decrement` trafficType set in `traffics.go`
* Added call when Splits are fetched to incr/decr counters for trafficTypeNames
* Added tests.

## How to test new changes?
* Run command `go test ./...`