### PR TITLE
[SDKS-575]: Store dynamic configs in redis when splitChanges is called

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+2.1.2 (, 2019)
+ - Added logic to store dynamic configs on splitChanges in redis mode.
 2.1.1 (March 8, 2019)
  - Updated Splits refreshing rate.
 2.1.0 (Jan 31, 2019)

--- a/splitio/api/dtos.go
+++ b/splitio/api/dtos.go
@@ -18,18 +18,18 @@ type SplitChangesDTO struct {
 
 // SplitDTO structure to map an Split definition fetched from JSON message.
 type SplitDTO struct {
-	ChangeNumber          int64           `json:"changeNumber"`
-	TrafficTypeName       string          `json:"trafficTypeName"`
-	Name                  string          `json:"name"`
-	TrafficAllocation     int             `json:"trafficAllocation"`
-	TrafficAllocationSeed int64           `json:"trafficAllocationSeed"`
-	Seed                  int64           `json:"seed"`
-	Status                string          `json:"status"`
-	Killed                bool            `json:"killed"`
-	DefaultTreatment      string          `json:"defaultTreatment"`
-	Algo                  int             `json:"algo"`
-	Conditions            []ConditionDTO  `json:"conditions"`
-	Configurations        json.RawMessage `json:"configurations"`
+	ChangeNumber          int64             `json:"changeNumber"`
+	TrafficTypeName       string            `json:"trafficTypeName"`
+	Name                  string            `json:"name"`
+	TrafficAllocation     int               `json:"trafficAllocation"`
+	TrafficAllocationSeed int64             `json:"trafficAllocationSeed"`
+	Seed                  int64             `json:"seed"`
+	Status                string            `json:"status"`
+	Killed                bool              `json:"killed"`
+	DefaultTreatment      string            `json:"defaultTreatment"`
+	Algo                  int               `json:"algo"`
+	Conditions            []ConditionDTO    `json:"conditions"`
+	Configurations        map[string]string `json:"configurations"`
 }
 
 // MarshalBinary exports SplitDTO to JSON string

--- a/splitio/api/dtos.go
+++ b/splitio/api/dtos.go
@@ -18,17 +18,18 @@ type SplitChangesDTO struct {
 
 // SplitDTO structure to map an Split definition fetched from JSON message.
 type SplitDTO struct {
-	ChangeNumber          int64          `json:"changeNumber"`
-	TrafficTypeName       string         `json:"trafficTypeName"`
-	Name                  string         `json:"name"`
-	TrafficAllocation     int            `json:"trafficAllocation"`
-	TrafficAllocationSeed int64          `json:"trafficAllocationSeed"`
-	Seed                  int64          `json:"seed"`
-	Status                string         `json:"status"`
-	Killed                bool           `json:"killed"`
-	DefaultTreatment      string         `json:"defaultTreatment"`
-	Algo                  int            `json:"algo"`
-	Conditions            []ConditionDTO `json:"conditions"`
+	ChangeNumber          int64           `json:"changeNumber"`
+	TrafficTypeName       string          `json:"trafficTypeName"`
+	Name                  string          `json:"name"`
+	TrafficAllocation     int             `json:"trafficAllocation"`
+	TrafficAllocationSeed int64           `json:"trafficAllocationSeed"`
+	Seed                  int64           `json:"seed"`
+	Status                string          `json:"status"`
+	Killed                bool            `json:"killed"`
+	DefaultTreatment      string          `json:"defaultTreatment"`
+	Algo                  int             `json:"algo"`
+	Conditions            []ConditionDTO  `json:"conditions"`
+	Configurations        json.RawMessage `json:"configurations"`
 }
 
 // MarshalBinary exports SplitDTO to JSON string

--- a/splitio/api/dtos_test.go
+++ b/splitio/api/dtos_test.go
@@ -24,7 +24,7 @@ var splitMock = `{
   "defaultTreatment": "of",
   "changeNumber": 1491244291288,
   "algo": 2,
-  "configurations": {"on":{"size":15}},
+  "configurations": {"on":"{\"size\":15}"},
   "conditions": [
     {
       "conditionType": "ROLLOUT",
@@ -144,11 +144,10 @@ func TestSplitDTOWithConfigs(t *testing.T) {
 			t.Error("Marshal struct mal formed [Killed]")
 		}
 
-		if string(splitChangesDtoFromMarshal.Splits[0].Configurations) !=
-			string(splitChangesDtoFromMock.Splits[0].Configurations) {
+		if string(splitChangesDtoFromMarshal.Splits[0].Configurations["on"]) !=
+			string(splitChangesDtoFromMock.Splits[0].Configurations["on"]) {
 			t.Error("Marshal struct mal formed [Configurations]")
 		}
-
 	}
 }
 

--- a/splitio/api/dtos_test.go
+++ b/splitio/api/dtos_test.go
@@ -24,6 +24,7 @@ var splitMock = `{
   "defaultTreatment": "of",
   "changeNumber": 1491244291288,
   "algo": 2,
+  "configurations": {"on":{"size":15}},
   "conditions": [
     {
       "conditionType": "ROLLOUT",
@@ -103,6 +104,49 @@ func TestSplitDTO(t *testing.T) {
 		if splitChangesDtoFromMarshal.Splits[0].Killed !=
 			splitChangesDtoFromMock.Splits[0].Killed {
 			t.Error("Marshal struct mal formed [Killed]")
+		}
+
+	}
+}
+
+func TestSplitDTOWithConfigs(t *testing.T) {
+	mockedData := fmt.Sprintf(splitsMock, splitMock)
+
+	var splitChangesDtoFromMock SplitChangesDTO
+	var splitChangesDtoFromMarshal SplitChangesDTO
+
+	err := json.Unmarshal([]byte(mockedData), &splitChangesDtoFromMock)
+	if err != nil {
+		t.Error("Error parsing split changes JSON ", err)
+	}
+
+	if dataSerialize, err := splitChangesDtoFromMock.Splits[0].MarshalBinary(); err != nil {
+		t.Error(err)
+	} else {
+		marshalData := fmt.Sprintf(splitsMock, dataSerialize)
+		err2 := json.Unmarshal([]byte(marshalData), &splitChangesDtoFromMarshal)
+		if err2 != nil {
+			t.Error("Error parsing split changes JSON ", err)
+		}
+
+		if splitChangesDtoFromMarshal.Splits[0].ChangeNumber !=
+			splitChangesDtoFromMock.Splits[0].ChangeNumber {
+			t.Error("Marshal struct mal formed [ChangeNumber]")
+		}
+
+		if splitChangesDtoFromMarshal.Splits[0].Name !=
+			splitChangesDtoFromMock.Splits[0].Name {
+			t.Error("Marshal struct mal formed [Name]")
+		}
+
+		if splitChangesDtoFromMarshal.Splits[0].Killed !=
+			splitChangesDtoFromMock.Splits[0].Killed {
+			t.Error("Marshal struct mal formed [Killed]")
+		}
+
+		if string(splitChangesDtoFromMarshal.Splits[0].Configurations) !=
+			string(splitChangesDtoFromMock.Splits[0].Configurations) {
+			t.Error("Marshal struct mal formed [Configurations]")
 		}
 
 	}

--- a/splitio/api/dtos_test.go
+++ b/splitio/api/dtos_test.go
@@ -17,15 +17,48 @@ var splitMock = `{
   "trafficTypeName": "user",
   "name": "DEMO_MURMUR2",
   "trafficAllocation": 100,
-  "trafficAllocationSeed": 1314112417,
-  "seed": -2059033614,
+  "trafficAllocationSeed": -929871296,
+  "seed": -871033445,
   "status": "ACTIVE",
   "killed": false,
-  "defaultTreatment": "of",
+  "defaultTreatment": "off",
   "changeNumber": 1491244291288,
   "algo": 2,
-  "configurations": {"on":"{\"size\":15}"},
+  "configurations": {
+    "on": "{\"color\": \"blue\",\"size\": 13}"
+  },
   "conditions": [
+    {
+      "conditionType": "WHITELIST",
+      "matcherGroup": {
+        "combiner": "AND",
+        "matchers": [
+          {
+            "keySelector": null,
+            "matcherType": "WHITELIST",
+            "negate": false,
+            "userDefinedSegmentMatcherData": null,
+            "whitelistMatcherData": {
+              "whitelist": [
+                "343454"
+              ]
+            },
+            "unaryNumericMatcherData": null,
+            "betweenMatcherData": null,
+            "booleanMatcherData": null,
+            "dependencyMatcherData": null,
+            "stringMatcherData": null
+          }
+        ]
+      },
+      "partitions": [
+        {
+          "treatment": "on",
+          "size": 100
+        }
+      ],
+      "label": "whitelisted"
+    },
     {
       "conditionType": "ROLLOUT",
       "matcherGroup": {
@@ -41,21 +74,24 @@ var splitMock = `{
             "userDefinedSegmentMatcherData": null,
             "whitelistMatcherData": null,
             "unaryNumericMatcherData": null,
-            "betweenMatcherData": null
+            "betweenMatcherData": null,
+            "booleanMatcherData": null,
+            "dependencyMatcherData": null,
+            "stringMatcherData": null
           }
         ]
       },
       "partitions": [
         {
           "treatment": "on",
-          "size": 0
+          "size": 50
         },
         {
-          "treatment": "of",
-          "size": 100
+          "treatment": "off",
+          "size": 50
         }
       ],
-      "label": "in segment all"
+      "label": "default rule"
     }
   ]
 }`

--- a/splitio/version.go
+++ b/splitio/version.go
@@ -2,4 +2,4 @@
 package splitio
 
 // Version is the version of this Agent
-const Version = "2.1.1"
+const Version = "2.1.2-rc1"


### PR DESCRIPTION
# Synchronizer

[SDKS-575: Store dynamic configs in redis when splitChanges is called](https://splitio.atlassian.net/browse/SDKS-575)

## Tickets covered:
* added support to dynamic configs by storing configurations

## What did you accomplish?
* Added rawMessage field in `SplitDTO`
* Updated tests.

## How to test new changes?
* Run command `go test ./...`