### PR TITLE
[SDKS-634]: /admin/healthcheck return errors for SDK and Event services

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-2.1.2 (March 28, 2019)
+2.1.2 (March 27, 2019)
  - Fixed healthcheck status.
 2.1.1 (March 8, 2019)
  - Updated Splits refreshing rate.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+2.1.2 (March 28, 2019)
+ - Fixed healthcheck status.
 2.1.1 (March 8, 2019)
  - Updated Splits refreshing rate.
 2.1.0 (Jan 31, 2019)

--- a/splitio/api/client.go
+++ b/splitio/api/client.go
@@ -22,8 +22,11 @@ const eventsURL = "https://events.split.io/api"
 const envSdkURLNamespace = "SPLITIO_SDK_URL"
 const envEventsURLNamespace = "SPLITIO_EVENTS_URL"
 
-var sdkClient *Client
-var eventsClient *Client
+// SdkClient exporting
+var SdkClient *Client
+
+// EventsClient exporting
+var EventsClient *Client
 
 // HttpError represetns a http error
 type HttpError struct {
@@ -40,19 +43,19 @@ func (h HttpError) Error() string {
 func Initialize() {
 	envSdkURL := os.Getenv(envSdkURLNamespace)
 	if envSdkURL != "" {
-		sdkClient = NewClient(envSdkURL)
+		SdkClient = NewClient(envSdkURL)
 		log.Debug.Println("SDK API Client created with endpoint ", envSdkURL)
 	} else {
-		sdkClient = NewClient(sdkURL)
+		SdkClient = NewClient(sdkURL)
 		log.Debug.Println("SDK API Client created with endpoint ", sdkURL)
 	}
 
 	envEventsURL := os.Getenv(envEventsURLNamespace)
 	if envEventsURL != "" {
-		eventsClient = NewClient(envEventsURL)
+		EventsClient = NewClient(envEventsURL)
 		log.Debug.Println("EVENTS API Client created with endpoint ", envEventsURL)
 	} else {
-		eventsClient = NewClient(eventsURL)
+		EventsClient = NewClient(eventsURL)
 		log.Debug.Println("EVENTS API Client created with endpoint ", eventsURL)
 	}
 }

--- a/splitio/api/client_test.go
+++ b/splitio/api/client_test.go
@@ -24,8 +24,8 @@ func before() {
 }
 
 func reset() {
-	sdkClient = nil
-	eventsClient = nil
+	SdkClient = nil
+	EventsClient = nil
 }
 
 func TestInitializeProd(t *testing.T) {
@@ -35,11 +35,11 @@ func TestInitializeProd(t *testing.T) {
 
 	Initialize()
 
-	if sdkClient == nil {
+	if SdkClient == nil {
 		t.Error("SDK client not initialized")
 	}
 
-	if eventsClient == nil {
+	if EventsClient == nil {
 		t.Error("Events client not initialized")
 	}
 
@@ -54,11 +54,11 @@ func TestInitialize(t *testing.T) {
 
 	Initialize()
 
-	if sdkClient == nil {
+	if SdkClient == nil {
 		t.Error("SDK client not initialized")
 	}
 
-	if eventsClient == nil {
+	if EventsClient == nil {
 		t.Error("Events client not initialized")
 	}
 
@@ -77,7 +77,7 @@ func TestGet(t *testing.T) {
 
 	Initialize()
 
-	txt, errg := sdkClient.Get("/")
+	txt, errg := SdkClient.Get("/")
 	if errg != nil {
 		t.Error(errg)
 	}
@@ -105,7 +105,7 @@ func TestGetGZIP(t *testing.T) {
 
 	Initialize()
 
-	txt, errg := sdkClient.Get("/")
+	txt, errg := SdkClient.Get("/")
 	if errg != nil {
 		t.Error(errg)
 	}
@@ -129,8 +129,8 @@ func TestPost(t *testing.T) {
 
 	Initialize()
 
-	sdkClient.AddHeader("someHeader", "HeaderValue")
-	errp := sdkClient.Post("/", []byte("some text"))
+	SdkClient.AddHeader("someHeader", "HeaderValue")
+	errp := SdkClient.Post("/", []byte("some text"))
 	if errp != nil {
 		t.Error(errp)
 	}
@@ -150,14 +150,14 @@ func TestHeaders(t *testing.T) {
 
 	Initialize()
 
-	sdkClient.AddHeader("someHeader", "HeaderValue")
-	_, ok1 := sdkClient.headers["someHeader"]
+	SdkClient.AddHeader("someHeader", "HeaderValue")
+	_, ok1 := SdkClient.headers["someHeader"]
 	if !ok1 {
 		t.Error("Header could not be added")
 	}
 
-	sdkClient.ResetHeaders()
-	_, ok2 := sdkClient.headers["someHeader"]
+	SdkClient.ResetHeaders()
+	_, ok2 := SdkClient.headers["someHeader"]
 	if ok2 {
 		t.Error("Reset Header fails")
 	}

--- a/splitio/api/fetchers.go
+++ b/splitio/api/fetchers.go
@@ -9,7 +9,7 @@ import (
 )
 
 func sdkFetch(url string) ([]byte, error) {
-	data, err := sdkClient.Get(url)
+	data, err := SdkClient.Get(url)
 	if err != nil {
 		return nil, err
 	}

--- a/splitio/api/post.go
+++ b/splitio/api/post.go
@@ -6,7 +6,7 @@ import (
 )
 
 func postToEventsServer(url string, data []byte, sdkVersion string, machineIP string, machineName string) error {
-	var _client = *eventsClient
+	var _client = *EventsClient
 	_client.ResetHeaders()
 	_client.AddHeader("SplitSDKVersion", sdkVersion)
 	_client.AddHeader("SplitSDKMachineIP", machineIP)

--- a/splitio/commitversion.go
+++ b/splitio/commitversion.go
@@ -5,4 +5,4 @@ This file is created automatically, please do not edit
 */
 
 // CommitVersion is the version of the last commit previous to release
-const CommitVersion = "968e72b"
+const CommitVersion = "cdabb0d"

--- a/splitio/version.go
+++ b/splitio/version.go
@@ -2,4 +2,4 @@
 package splitio
 
 // Version is the version of this Agent
-const Version = "2.1.1"
+const Version = "2.1.2-rc1"

--- a/splitio/version.go
+++ b/splitio/version.go
@@ -2,4 +2,4 @@
 package splitio
 
 // Version is the version of this Agent
-const Version = "2.1.2-rc1"
+const Version = "2.1.2"

--- a/splitio/web/admin/controllers/common.go
+++ b/splitio/web/admin/controllers/common.go
@@ -1,8 +1,9 @@
 package controllers
 
 import (
-	"net/http"
-	"os"
+	"github.com/splitio/split-synchronizer/splitio/api"
+
+	"github.com/splitio/split-synchronizer/log"
 )
 
 const envSdkURLNamespace = "SPLITIO_SDK_URL"
@@ -10,12 +11,12 @@ const envEventsURLNamespace = "SPLITIO_EVENTS_URL"
 
 // GetSdkStatus checks the status of the SDK Server
 func GetSdkStatus() map[string]interface{} {
-	sdkURL := os.Getenv(envSdkURLNamespace) + "/version"
+	_, err := api.SdkClient.Get("/version")
 	sdkStatus := make(map[string]interface{})
-	resp, err := http.Get(sdkURL)
-	if err != nil || (resp != nil && resp.StatusCode != 200) {
+	if err != nil {
 		sdkStatus["healthy"] = false
 		sdkStatus["message"] = "Cannot reach SDK service"
+		log.Debug.Println("Events Server:", err)
 	} else {
 		sdkStatus["healthy"] = true
 		sdkStatus["message"] = "SDK service working as expected"
@@ -25,12 +26,12 @@ func GetSdkStatus() map[string]interface{} {
 
 // GetEventsStatus checks the status of the Events Server
 func GetEventsStatus() map[string]interface{} {
-	eventsURL := os.Getenv(envEventsURLNamespace) + "/version"
+	_, err := api.EventsClient.Get("/version")
 	eventsStatus := make(map[string]interface{})
-	resp, err := http.Get(eventsURL)
-	if err != nil || (resp != nil && resp.StatusCode != 200) {
+	if err != nil {
 		eventsStatus["healthy"] = false
 		eventsStatus["message"] = "Cannot reach Events service"
+		log.Debug.Println("Events Server:", err)
 	} else {
 		eventsStatus["healthy"] = true
 		eventsStatus["message"] = "Events service working as expected"


### PR DESCRIPTION
# Synchronizer

## Tickets covered:
* [SDKS-634: /admin/healthcheck return errors for SDK and Event services](https://splitio.atlassian.net/browse/SDKS-634)

## What did you accomplish?
* Replaced healtcheck to grab SdkClient and EventClient

## How to test new changes?
* Run command `go test ./...`
