### PR TITLE
Docker Push to Artifactory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ jobs:
   include:
     - stage: test
       language: go
-      go:
-        - 1.8.x
-        - 1.13.x
+      matrix:
+        include:
+          - go: '1.8.x'
+          - go: '1.13.x'
       services:
         - redis-server
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ jobs:
       script:
         - cd ${TRAVIS_BUILD_DIR}/release
         - sh build.sh
+      before_deploy:
         - cd ${TRAVIS_BUILD_DIR}/release
         - cat versions.pre.html versions.html versions.pos.html > deploy/synchronizer/versions.html
         - cp install_linux_*.bin deploy/synchronizer/${BUILD_VERSION}/
@@ -38,9 +39,6 @@ jobs:
         - cp install_linux_*.bin ../install_linux.bin
         - cp install_osx_*.bin ../install_osx.bin
         - cp split-sync-win_*.zip ../split-sync-win.zip
-        # Debug
-        - cd ${TRAVIS_BUILD_DIR}
-        - ls -R release/deploy
       deploy:
         provider: s3
         access_key_id: ${AWS_ACCESS_KEY_ID}
@@ -61,71 +59,17 @@ jobs:
         - BUILD_VERSION=$(tail -n 1 splitio/version.go | awk '{print $4}' | tr -d '"')
       script:
         - docker build -t ${ARTIFACTORY_REGISTRY}/split-synchronizer:${BUILD_VERSION} -t ${ARTIFACTORY_REGISTRY}/split-synchronizer:latest .
+      deploy:
+        provider: script
+        script: >-
+          echo "${ARTIFACTORY_PASSWORD}" | docker login -u "${ARTIFACTORY_USER}" --password-stdin "${ARTIFACTORY_REGISTRY}" &&
+          docker push ${ARTIFACTORY_REGISTRY}/split-synchronizer
+        skip_cleanup: true
+        on:
+          all_branches: true
 
 stages:
   - name: test
   - name: build
   - name: xray
     if: (branch = development OR branch = master OR branch = INFRA-1540) OR (type = cron)
-
-#####################
-#
-# language: go
-#
-# go:
-#   - 1.9.x
-#
-# services:
-#   - docker
-#   - redis-server
-#
-# before_script:
-#   - BUILD_VERSION=$(tail -n 1 splitio/version.go | awk '{print $4}' | tr -d '"')
-#   - mkdir -p release/deploy/synchronizer/${BUILD_VERSION}
-#
-# script:
-#   - go test -v -cover $(go list ./... | grep -v /vendor/)
-#
-# before_install:
-#   - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-#
-# install:
-#   - dep ensure
-#
-# after_success:
-#   - docker build -t splitsoftware/split-synchronizer:${BUILD_VERSION} -t splitsoftware/split-synchronizer:latest .
-#   - cd ${TRAVIS_BUILD_DIR}/release
-#   - sh build.sh
-#
-# before_deploy:
-#   # Move files
-#   - cd ${TRAVIS_BUILD_DIR}/release
-#   - cat versions.pre.html versions.html versions.pos.html > deploy/synchronizer/versions.html
-#   - cp install_linux_*.bin deploy/synchronizer/${BUILD_VERSION}
-#   - cp install_osx_*.bin deploy/synchronizer/${BUILD_VERSION}
-#   - cp split-sync-win_*.zip deploy/synchronizer/${BUILD_VERSION}
-#   # Create copies
-#   - cd deploy/synchronizer/${BUILD_VERSION}
-#   - cp install_linux_*.bin ../install_linux.bin
-#   - cp install_osx_*.bin ../install_osx.bin
-#   - cp split-sync-win_*.zip ../split-sync-win.zip
-#   # List files
-#   - cd ${TRAVIS_BUILD_DIR}
-#   - ls -R release/deploy
-#
-# deploy:
-#   - provider: s3
-#     access_key_id: ${AWS_ACCESS_KEY_ID}
-#     secret_access_key: ${AWS_SECRET_ACCESS_KEY}
-#     bucket: downloads.split.io
-#     region: us-east-1
-#     local_dir: ${TRAVIS_BUILD_DIR}/release/deploy
-#     skip_cleanup: true
-#     acl: public_read
-#     on:
-#       branch: master
-#   - provider: script
-#     script: bash docker_push
-#     skip_cleanup: true
-#     on:
-#       branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,59 +1,73 @@
-language: go
+jobs:
+  include:
+    - stage: test
+      language: go
+      go:
+        - 1.8.x
+        - 1.13.x
+      services:
+        - redis-server
+      script:
+        - go test -v -cover $(go list ./... | grep -v /vendor/)
 
-go:
-  - 1.9.x
-
-services:
-  - docker
-  - redis-server
-
-before_script:
-  - BUILD_VERSION=$(tail -n 1 splitio/version.go | awk '{print $4}' | tr -d '"')
-  - mkdir -p release/deploy/synchronizer/${BUILD_VERSION}
-
-script:
-  - go test -v -cover $(go list ./... | grep -v /vendor/)
-
-before_install:                                                                 
-  - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-  
-install:
-  - dep ensure
-
-after_success:
-  - docker build -t splitsoftware/split-synchronizer:${BUILD_VERSION} -t splitsoftware/split-synchronizer:latest .
-  - cd ${TRAVIS_BUILD_DIR}/release
-  - sh build.sh
-
-before_deploy:
-  # Move files
-  - cd ${TRAVIS_BUILD_DIR}/release
-  - cat versions.pre.html versions.html versions.pos.html > deploy/synchronizer/versions.html
-  - cp install_linux_*.bin deploy/synchronizer/${BUILD_VERSION}
-  - cp install_osx_*.bin deploy/synchronizer/${BUILD_VERSION}
-  - cp split-sync-win_*.zip deploy/synchronizer/${BUILD_VERSION}
-  # Create copies
-  - cd deploy/synchronizer/${BUILD_VERSION}
-  - cp install_linux_*.bin ../install_linux.bin
-  - cp install_osx_*.bin ../install_osx.bin
-  - cp split-sync-win_*.zip ../split-sync-win.zip
-  # List files
-  - cd ${TRAVIS_BUILD_DIR}
-  - ls -R release/deploy
-
-deploy:
-  - provider: s3
-    access_key_id: ${AWS_ACCESS_KEY_ID}
-    secret_access_key: ${AWS_SECRET_ACCESS_KEY}
-    bucket: downloads.split.io
-    region: us-east-1
-    local_dir: ${TRAVIS_BUILD_DIR}/release/deploy
-    skip_cleanup: true
-    acl: public_read
-    on:
-      branch: master
-  - provider: script
-    script: bash docker_push
-    skip_cleanup: true
-    on:
-      branch: master
+#####################
+#
+# language: go
+#
+# go:
+#   - 1.9.x
+#
+# services:
+#   - docker
+#   - redis-server
+#
+# before_script:
+#   - BUILD_VERSION=$(tail -n 1 splitio/version.go | awk '{print $4}' | tr -d '"')
+#   - mkdir -p release/deploy/synchronizer/${BUILD_VERSION}
+#
+# script:
+#   - go test -v -cover $(go list ./... | grep -v /vendor/)
+#
+# before_install:
+#   - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+#
+# install:
+#   - dep ensure
+#
+# after_success:
+#   - docker build -t splitsoftware/split-synchronizer:${BUILD_VERSION} -t splitsoftware/split-synchronizer:latest .
+#   - cd ${TRAVIS_BUILD_DIR}/release
+#   - sh build.sh
+#
+# before_deploy:
+#   # Move files
+#   - cd ${TRAVIS_BUILD_DIR}/release
+#   - cat versions.pre.html versions.html versions.pos.html > deploy/synchronizer/versions.html
+#   - cp install_linux_*.bin deploy/synchronizer/${BUILD_VERSION}
+#   - cp install_osx_*.bin deploy/synchronizer/${BUILD_VERSION}
+#   - cp split-sync-win_*.zip deploy/synchronizer/${BUILD_VERSION}
+#   # Create copies
+#   - cd deploy/synchronizer/${BUILD_VERSION}
+#   - cp install_linux_*.bin ../install_linux.bin
+#   - cp install_osx_*.bin ../install_osx.bin
+#   - cp split-sync-win_*.zip ../split-sync-win.zip
+#   # List files
+#   - cd ${TRAVIS_BUILD_DIR}
+#   - ls -R release/deploy
+#
+# deploy:
+#   - provider: s3
+#     access_key_id: ${AWS_ACCESS_KEY_ID}
+#     secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+#     bucket: downloads.split.io
+#     region: us-east-1
+#     local_dir: ${TRAVIS_BUILD_DIR}/release/deploy
+#     skip_cleanup: true
+#     acl: public_read
+#     on:
+#       branch: master
+#   - provider: script
+#     script: bash docker_push
+#     skip_cleanup: true
+#     on:
+#       branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,8 @@ jobs:
   include:
     - stage: test
       language: go
-      matrix:
-        include:
-          - go: '1.8.x'
-          - go: '1.13.x'
+      go:
+        - 1.9.x
       services:
         - redis-server
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,62 @@ jobs:
       script:
         - go test -v -cover $(go list ./... | grep -v /vendor/)
 
+    - stage: build
+      language: go
+      go:
+        - 1.9.x
+      services:
+        - redis-server
+      before_install:
+        - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+      install:
+        - dep ensure
+      before_script:
+        - BUILD_VERSION=$(tail -n 1 splitio/version.go | awk '{print $4}' | tr -d '"')
+        - mkdir -p ${TRAVIS_BUILD_DIR}/release/deploy/synchronizer/${BUILD_VERSION}
+      script:
+        - cd ${TRAVIS_BUILD_DIR}/release
+        - sh build.sh
+      before_deploy:
+        - cd ${TRAVIS_BUILD_DIR}/release
+        - cat versions.pre.html versions.html versions.pos.html > deploy/synchronizer/versions.html
+        - cp install_linux_*.bin deploy/synchronizer/${BUILD_VERSION}/
+        - cp install_osx_*.bin deploy/synchronizer/${BUILD_VERSION}/
+        - cp split-sync-win_*.zip deploy/synchronizer/${BUILD_VERSION}/
+        - cd ${TRAVIS_BUILD_DIR}/release/deploy/synchronizer/${BUILD_VERSION}
+        - cp install_linux_*.bin ../install_linux.bin
+        - cp install_osx_*.bin ../install_osx.bin
+        - cp split-sync-win_*.zip ../split-sync-win.zip
+        # Debug
+        - cd ${TRAVIS_BUILD_DIR}
+        - ls -R release/deploy
+      deploy:
+        provider: s3
+        access_key_id: ${AWS_ACCESS_KEY_ID}
+        secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+        bucket: downloads.split.io
+        region: us-east-1
+        local_dir: ${TRAVIS_BUILD_DIR}/release/deploy
+        skip_cleanup: true
+        acl: public_read
+        on:
+          branch: master
+
+    - stage: xray
+      language: minimal
+      services:
+        - docker
+      before_script:
+        - BUILD_VERSION=$(tail -n 1 splitio/version.go | awk '{print $4}' | tr -d '"')
+      script:
+        - docker build -t ${ARTIFACTORY_REGISTRY}/split-synchronizer:${BUILD_VERSION} -t ${ARTIFACTORY_REGISTRY}/split-synchronizer:latest .
+
+stages:
+  - name: test
+  - name: build
+  - name: xray
+    if: (branch = development OR branch = master OR branch = INFRA-1540) OR (type = cron)
+
 #####################
 #
 # language: go

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ jobs:
       script:
         - cd ${TRAVIS_BUILD_DIR}/release
         - sh build.sh
-      before_deploy:
         - cd ${TRAVIS_BUILD_DIR}/release
         - cat versions.pre.html versions.html versions.pos.html > deploy/synchronizer/versions.html
         - cp install_linux_*.bin deploy/synchronizer/${BUILD_VERSION}/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ jobs:
         - 1.9.x
       services:
         - redis-server
+      before_install:
+        - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+      install:
+        - dep ensure
       script:
         - go test -v -cover $(go list ./... | grep -v /vendor/)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,4 +72,4 @@ stages:
   - name: test
   - name: build
   - name: xray
-    if: (branch = development OR branch = master OR branch = INFRA-1540) OR (type = cron)
+    if: (branch = master) OR (type = cron)


### PR DESCRIPTION
# Split Synchronizer

## What did you accomplish?
Three different Travis' stages:

- Run the tests (always).
- Run the build (always) and deploy to S3 (only on master).
- Docker build and push to Artifactory (only on master).
- CRON the Docker stage (daily).

**The automatic deployment to Dockerhub was removed due to security concerns.**

## How do we test the changes introduced in this PR?
Check TravisCI output.

## Extra Notes
Testing multiple versions at the moment is not possible because Travis doesn't support Matrix expansion within a given stage, [link to the issue](https://github.com/travis-ci/travis-ci/issues/8295).