### PR TITLE
added do not send ip address flag and honors ip from redis

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+2.5.3 (October XX, 2019)
+ - Added flag `IPAddressesEnabled` into config to enable/disable sending machineName and machineIp when data is posted in headers.
+
 2.5.2 (September 25, 2019)
  - Update docker base image to patch security vulnerabilities.
 

--- a/conf/parser.go
+++ b/conf/parser.go
@@ -233,5 +233,6 @@ func getDefaultConfigData() ConfigData {
 	configData.Proxy.Auth.APIKeys = append(configData.Proxy.Auth.APIKeys, "SDK_API_KEY")
 	var configDataReflection = reflect.ValueOf(&configData).Elem()
 	loadDefaultValuesRecursiveChildren(configDataReflection)
+	configData.IPAddressesEnabled = true
 	return configData
 }

--- a/conf/sections.go
+++ b/conf/sections.go
@@ -87,9 +87,10 @@ type ConfigData struct {
 	EventsPerPost              int                `json:"eventsPerPost" split-default-value:"10000" split-cli-option:"events-per-post" split-cli-description:"Number of events to send in a POST request"`
 	EventsConsumerThreads      int                `json:"eventsConsumerThreads" split-default-value:"0" split-cli-option:"events-consumer-threads" split-cli-description:"Number of events consumer threads"`
 	EventsThreads              int                `json:"eventsThreads" split-default-value:"1" split-cli-option:"events-threads" split-cli-description:"Number of events threads"`
-	MetricsPostRate            int                `json:"metricsPostRate" split-default-value:"60" split-cli-option:"metrics-post-rate" split-cli-description:"Post rate of metrics recorder,-"`
-	MetricsRefreshRate         int                `json:"metricsRefreshRate" split-default-value:"0" split-cli-option:"metrics-refresh-rate" split-cli-description:"Post rate of metrics recorder,-"`
+	MetricsPostRate            int                `json:"metricsPostRate" split-default-value:"60" split-cli-option:"metrics-post-rate" split-cli-description:"Post rate of metrics recorder"`
+	MetricsRefreshRate         int                `json:"metricsRefreshRate" split-default-value:"0" split-cli-option:"metrics-refresh-rate" split-cli-description:"Post rate of metrics recorder"`
 	HTTPTimeout                int64              `json:"httpTimeout" split-default-value:"60" split-cli-option:"http-timeout" split-cli-description:"Timeout specifies a time limit for requests"`
+	IPAddressesEnabled         bool               `json:"IPAddressesEnabled" split-default-value:"true" split-cli-option:"ip-addresses-enabled" split-cli-description:"Flag to disable IP addresses and host name from being sent to the Split backend"`
 }
 
 //MarshalBinary exports ConfigData to JSON string

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,7 @@
 #    - SPLIT_SYNC_LOG_BACKUP_COUNT             Number of last log files to keep in filesystem
 #    - SPLIT_SYNC_LOG_SLACK_CHANNEL            Set the Slack channel or user
 #    - SPLIT_SYNC_LOG_SLACK_WEBHOOK            Set the Slack webhook url
+#    - SPLIT_SYNC_IP_ADDRESSES_ENABLED         Flag to disable IP addresses and host name from being sent to the Split backend
 #
 #    - SPLIT_SYNC_ADVANCED_PARAMETERS          Set custom parameters that are not configured via provided Env vars.
 #                                              Sample:
@@ -151,6 +152,10 @@ fi
 
 if [ ! -z ${SPLIT_SYNC_IMPRESSION_LISTENER_ENDPOINT+x} ]; then
   PARAMETERS="${PARAMETERS} -impression-listener-endpoint=${SPLIT_SYNC_IMPRESSION_LISTENER_ENDPOINT}"
+fi
+
+if [ ! -z ${SPLIT_SYNC_IP_ADDRESSES_ENABLED+x} ]; then
+  PARAMETERS="${PARAMETERS} -ip-addresses-enabled=${SPLIT_SYNC_IP_ADDRESSES_ENABLED}"
 fi
 
 

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -22,7 +22,6 @@ func TestSlackWriter(t *testing.T) {
 
 		expectedJSON := `{"channel": "some-channel", "username": "Split-Sync", "text": "Some error message", "icon_emoji": ":robot_face:"}`
 		rBody, _ := ioutil.ReadAll(r.Body)
-		fmt.Println(string(rBody))
 
 		if string(rBody) != expectedJSON {
 			t.Error("malformed JSON at SLACK message")

--- a/splitio/api/post.go
+++ b/splitio/api/post.go
@@ -9,11 +9,13 @@ func postToEventsServer(url string, data []byte, sdkVersion string, machineIP st
 	var _client = *EventsClient
 	_client.ResetHeaders()
 	_client.AddHeader("SplitSDKVersion", sdkVersion)
-	_client.AddHeader("SplitSDKMachineIP", machineIP)
-	if machineName == "" && machineIP != "" {
-		_client.AddHeader("SplitSDKMachineName", fmt.Sprintf("ip-%s", strings.Replace(machineIP, ".", "-", -1)))
-	} else {
-		_client.AddHeader("SplitSDKMachineName", machineName)
+	if machineName != "na" && machineName != "unknown" && machineIP != "na" && machineIP != "unknown" {
+		_client.AddHeader("SplitSDKMachineIP", machineIP)
+		if machineName == "" && machineIP != "" {
+			_client.AddHeader("SplitSDKMachineName", fmt.Sprintf("ip-%s", strings.Replace(machineIP, ".", "-", -1)))
+		} else {
+			_client.AddHeader("SplitSDKMachineName", machineName)
+		}
 	}
 
 	err := _client.Post(url, data)

--- a/splitio/api/post_test.go
+++ b/splitio/api/post_test.go
@@ -37,7 +37,6 @@ func TestPostImpressions(t *testing.T) {
 		}
 
 		rBody, _ := ioutil.ReadAll(r.Body)
-		//fmt.Println(string(rBody))
 		var impressionsInPost []ImpressionsDTO
 		err := json.Unmarshal(rBody, &impressionsInPost)
 		if err != nil {

--- a/splitio/nethelper/netip.go
+++ b/splitio/nethelper/netip.go
@@ -2,15 +2,19 @@
 package nethelper
 
 import (
-	"errors"
 	"net"
+
+	"github.com/splitio/split-synchronizer/conf"
 )
 
 // ExternalIP tries to fetch server IP
-func ExternalIP() (string, error) {
+func ExternalIP() string {
+	if !conf.Data.IPAddressesEnabled {
+		return "na"
+	}
 	ifaces, err := net.Interfaces()
 	if err != nil {
-		return "", err
+		return "unknown"
 	}
 	for _, iface := range ifaces {
 		if iface.Flags&net.FlagUp == 0 {
@@ -21,7 +25,7 @@ func ExternalIP() (string, error) {
 		}
 		addrs, err := iface.Addrs()
 		if err != nil {
-			return "", err
+			return "unknown"
 		}
 		for _, addr := range addrs {
 			var ip net.IP
@@ -38,8 +42,8 @@ func ExternalIP() (string, error) {
 			if ip == nil {
 				continue // not an ipv4 address
 			}
-			return ip.String(), nil
+			return ip.String()
 		}
 	}
-	return "", errors.New("IP could not be found")
+	return "unknown"
 }

--- a/splitio/proxy/controllers/impressions_test.go
+++ b/splitio/proxy/controllers/impressions_test.go
@@ -55,7 +55,7 @@ func TestAddImpressions(t *testing.T) {
 		}
 
 		rBody, _ := ioutil.ReadAll(r.Body)
-		//fmt.Println(string(rBody))
+
 		var impressionsInPost []api.ImpressionsDTO
 		err := json.Unmarshal(rBody, &impressionsInPost)
 		if err != nil {

--- a/splitio/recorder/impressions_test.go
+++ b/splitio/recorder/impressions_test.go
@@ -37,7 +37,7 @@ func TestImpressionsHTTPRecorderPOST(t *testing.T) {
 		}
 
 		rBody, _ := ioutil.ReadAll(r.Body)
-		//fmt.Println(string(rBody))
+
 		var impressionsInPost []api.ImpressionsDTO
 		err := json.Unmarshal(rBody, &impressionsInPost)
 		if err != nil {

--- a/splitio/stats/counter/counter.go
+++ b/splitio/stats/counter/counter.go
@@ -91,11 +91,7 @@ func (c *Counter) PostCounterWorker() {
 
 		if len(countersDataSet) > 0 {
 			sdkVersion := appcontext.VersionHeader()
-			machineIP, err := nethelper.ExternalIP()
-			if err != nil {
-				machineIP = "unknown"
-			}
-			errc := c.recorderAdapter.PostCounters(countersDataSet, sdkVersion, machineIP)
+			errc := c.recorderAdapter.PostCounters(countersDataSet, sdkVersion, nethelper.ExternalIP())
 			if errc != nil {
 				log.Error.Println(errc)
 			}

--- a/splitio/stats/counter/counter_test.go
+++ b/splitio/stats/counter/counter_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/splitio/split-synchronizer/conf"
+
 	"github.com/splitio/split-synchronizer/appcontext"
 
 	"github.com/splitio/split-synchronizer/log"
@@ -33,6 +35,9 @@ func TestCounter(t *testing.T) {
 	counterA := "COUNTER_A"
 	counterB := "COUNTER_B"
 
+	conf.Initialize()
+	conf.Data.IPAddressesEnabled = false
+
 	var expectedA int64 = 1 + 7 - 1 - 5
 	var expectedB int64 = 1 + 5 - 1 - 15
 
@@ -48,13 +53,13 @@ func TestCounter(t *testing.T) {
 			t.Error("SDK Version HEADER not match")
 		}
 
-		if sdkMachine == "" {
-			t.Error("SDK Machine HEADER not match")
+		if sdkMachine != "" {
+			t.Error("Header should not be present")
 		}
 
 		sdkMachineName := r.Header.Get("SplitSDKMachineName")
-		if sdkMachineName == "" {
-			t.Error("SDK Machine Name HEADER not match", sdkMachineName)
+		if sdkMachineName != "" {
+			t.Error("Header should not be present")
 		}
 
 		rBody, _ := ioutil.ReadAll(r.Body)

--- a/splitio/stats/latency/latency.go
+++ b/splitio/stats/latency/latency.go
@@ -97,13 +97,8 @@ func (l *Latency) PostLatenciesWorker(f stats.LatencyStorageAddFunc) {
 
 		l.lmutex.Unlock()
 		sdkVersion := appcontext.VersionHeader()
-		machineIP, err := nethelper.ExternalIP()
-		if err != nil {
-			machineIP = "unknown"
-		}
-
 		if len(latenciesDataSet) > 0 {
-			errp := l.recorderAdapter.PostLatencies(latenciesDataSet, sdkVersion, machineIP)
+			errp := l.recorderAdapter.PostLatencies(latenciesDataSet, sdkVersion, nethelper.ExternalIP())
 			if errp != nil {
 				log.Error.Println("Go-proxy latencies worker:", errp)
 			}

--- a/splitio/stats/latency/latency_test.go
+++ b/splitio/stats/latency/latency_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/splitio/split-synchronizer/appcontext"
-
+	"github.com/splitio/split-synchronizer/conf"
 	"github.com/splitio/split-synchronizer/log"
 	"github.com/splitio/split-synchronizer/splitio"
 	"github.com/splitio/split-synchronizer/splitio/api"
@@ -20,6 +20,9 @@ import (
 func TestLatency(t *testing.T) {
 
 	latencyA := "LATENCY_A"
+
+	conf.Initialize()
+	conf.Data.IPAddressesEnabled = false
 
 	stdoutWriter := ioutil.Discard //os.Stdout
 	log.Initialize(stdoutWriter, stdoutWriter, stdoutWriter, stdoutWriter, stdoutWriter, stdoutWriter)
@@ -33,17 +36,17 @@ func TestLatency(t *testing.T) {
 			t.Error("SDK Version HEADER not match")
 		}
 
-		if sdkMachine == "" {
-			t.Error("SDK Machine HEADER not match")
+		if sdkMachine != "" {
+			t.Error("SDK Machine should not be present")
 		}
 
 		sdkMachineName := r.Header.Get("SplitSDKMachineName")
-		if sdkMachineName == "" {
-			t.Error("SDK Machine Name HEADER not match", sdkMachineName)
+		if sdkMachineName != "" {
+			t.Error("SDK Machine Name should not be present")
 		}
 
 		rBody, _ := ioutil.ReadAll(r.Body)
-		//fmt.Println(string(rBody))
+
 		var latenciesInPost []api.LatenciesDTO
 		err := json.Unmarshal(rBody, &latenciesInPost)
 		if err != nil {
@@ -99,6 +102,8 @@ func TestLatencyBucket(t *testing.T) {
 
 	latencyA := "LATENCY_BKT"
 
+	conf.Initialize()
+
 	stdoutWriter := ioutil.Discard //os.Stdout
 	log.Initialize(stdoutWriter, stdoutWriter, stdoutWriter, stdoutWriter, stdoutWriter, stdoutWriter)
 
@@ -121,7 +126,7 @@ func TestLatencyBucket(t *testing.T) {
 		}
 
 		rBody, _ := ioutil.ReadAll(r.Body)
-		//fmt.Println(string(rBody))
+
 		var latenciesInPost []api.LatenciesDTO
 		err := json.Unmarshal(rBody, &latenciesInPost)
 		if err != nil {

--- a/splitio/version.go
+++ b/splitio/version.go
@@ -2,4 +2,4 @@
 package splitio
 
 // Version is the version of this Agent
-const Version = "2.5.2"
+const Version = "2.5.3-rc1"


### PR DESCRIPTION
# Split Synchronizer

## What did you accomplish?
- Honor what comes from redis to not send machine name and machine ip to Split Servers.
- Added `IPAddressesEnabled` flag to enable/disable sending data to Split Servers for metrics/counters and gauges,

## How do we test the changes introduced in this PR?
- `go test ./...`
- Check in Split UI if machine ip and machine name is not displayed when you disable the flag.

## Extra Notes