### PR TITLE
Staging

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
 2.6.1 (Nov 27, 2019)
- - Point to specific version of gin-gonic due of deprecation of go 1.8, 1.9 in gin 1.5.0.
+ - Pin gin-gonic framework version to remain compatible with go <= 1.9.
 
 2.6.0 (Nov 1, 2019)
  - Cleanup redis before initialization if apikey differs

--- a/splitio/commitversion.go
+++ b/splitio/commitversion.go
@@ -5,4 +5,4 @@ This file is created automatically, please do not edit
 */
 
 // CommitVersion is the version of the last commit previous to release
-const CommitVersion = "a6384ff"
+const CommitVersion = "daaa840"

--- a/splitio/version.go
+++ b/splitio/version.go
@@ -2,4 +2,4 @@
 package splitio
 
 // Version is the version of this Agent
-const Version = "2.6.1-rc1"
+const Version = "2.6.1"


### PR DESCRIPTION
# Split Synchronizer

## What did you accomplish?
- Forced dependency on gin to `1.3` due that gin last version deprecates go `1.8` and `1.9` versions.

## How do we test the changes introduced in this PR?

## Extra Notes