### PR TITLE
fixed: Warning fetching segments updates hitting admin URL

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+2.6.2 (Coming soon)
+ - Fixed warnings fetching segments.
+
 2.6.1 (Nov 27, 2019)
  - Pin gin-gonic framework version to remain compatible with go <= 1.9.
 

--- a/splitio/task/fetchsegments.go
+++ b/splitio/task/fetchsegments.go
@@ -73,15 +73,15 @@ func (j job) run() {
 		segmentChangeFetcherLocalCounters.Increment("backend::request.ok")
 		log.Debug.Println(">>>> Fetched segment:", segment.Name)
 
+		//updating change number
+		j.segmentStorage.SetChangeNumber(segment.Name, segment.Till)
+		
 		if lastChangeNumber >= segment.Till {
 			log.Debug.Println("Segments returned by the server are empty")
 			//Unlock channel
 			<-blocker
 			return
 		}
-
-		//updating change number
-		j.segmentStorage.SetChangeNumber(segment.Name, segment.Till)
 
 		//adding new keys to segment
 		if err := j.segmentStorage.AddToSegment(segment.Name, segment.Added); err != nil {

--- a/splitio/version.go
+++ b/splitio/version.go
@@ -2,4 +2,4 @@
 package splitio
 
 // Version is the version of this Agent
-const Version = "2.6.1"
+const Version = "2.6.2-rc1"


### PR DESCRIPTION
# Split Synchronizer

## What did you accomplish?
Fixed warnings when fetching segments without users.

## How do we test the changes introduced in this PR?
Added a new tests for this scenario. 

## Extra Notes