### PR TITLE
avoid logging info routes in release mode

### DIFF
--- a/splitio/web/admin/router.go
+++ b/splitio/web/admin/router.go
@@ -33,13 +33,14 @@ func StartAdminWebAdmin(options *WebAdminOptions, storages common.Storages, http
 }
 
 func newWebAdminServer(options *WebAdminOptions, storages common.Storages, httpClients common.HTTPClients, recorders common.Recorders) *WebAdminServer {
-	if !options.DebugOn {
-		gin.SetMode(gin.ReleaseMode)
-	}
-
 	server := &WebAdminServer{options: options, router: gin.New()}
 	server.router.Use(gin.Recovery())
-	server.router.Use(gin.Logger())
+	if !options.DebugOn {
+		gin.SetMode(gin.ReleaseMode)
+		server.router.Use(gin.LoggerWithWriter(gin.DefaultWriter, []string{"/admin/healthcheck", "/admin/ping", "/admin/uptime", "/admin/version"}...))
+	} else {
+		server.router.Use(gin.Logger())
+	}
 
 	if options.AdminUsername != "" && options.AdminPassword != "" {
 		server.router.Use(middleware.HTTPBasicAuth(options.AdminUsername, options.AdminPassword))

--- a/splitio/web/admin/router.go
+++ b/splitio/web/admin/router.go
@@ -37,7 +37,7 @@ func newWebAdminServer(options *WebAdminOptions, storages common.Storages, httpC
 	server.router.Use(gin.Recovery())
 	if !options.DebugOn {
 		gin.SetMode(gin.ReleaseMode)
-		server.router.Use(gin.LoggerWithWriter(gin.DefaultWriter, []string{"/admin/healthcheck", "/admin/ping", "/admin/uptime", "/admin/version"}...))
+		server.router.Use(gin.LoggerWithWriter(gin.DefaultWriter, "/admin/healthcheck", "/admin/ping", "/admin/uptime", "/admin/version"))
 	} else {
 		server.router.Use(gin.Logger())
 	}


### PR DESCRIPTION
# Split Synchronizer

## What did you accomplish?
- Avoiding logging stats routes when Sync is not in debug mode.

## How do we test the changes introduced in this PR?

## Extra Notes