### PR TITLE
observable split & segment storages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gin-gonic/gin v1.7.7
 	github.com/google/uuid v1.3.0
 	github.com/splitio/gincache v0.0.1-rc7
-	github.com/splitio/go-split-commons/v4 v4.0.2
+	github.com/splitio/go-split-commons/v4 v4.0.3-rc1
 	github.com/splitio/go-toolkit/v5 v5.0.3
 	go.etcd.io/bbolt v1.3.6
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/splitio/gincache v0.0.1-rc7 h1:BNIP3uaT4zqRepYwi6TRJevzPX3EsgUnLSA3nwNu5tw=
 github.com/splitio/gincache v0.0.1-rc7/go.mod h1:IUKPDIlTSH8bNqpgMDWjgrbbkqhApnQHSxXp5uKjGg8=
-github.com/splitio/go-split-commons/v4 v4.0.2 h1:caXg/uUAwBLsPbgp+rOTQkecX7Sq8y4EtAChUICkt44=
-github.com/splitio/go-split-commons/v4 v4.0.2/go.mod h1:42zur2Zsz0Y6aQ3r5Zmqkhq6/vlNF56B9BXW+QpIEeo=
+github.com/splitio/go-split-commons/v4 v4.0.3-rc1 h1:o8cWCgCwjqDGTD+FdcxKjwkWztJQ/LUjuAnuxttfKRY=
+github.com/splitio/go-split-commons/v4 v4.0.3-rc1/go.mod h1:42zur2Zsz0Y6aQ3r5Zmqkhq6/vlNF56B9BXW+QpIEeo=
 github.com/splitio/go-toolkit/v5 v5.0.3 h1:3LrhJo76ZYTsi/cWS2pDfH6+ImKlOqtp3J98qm4WGpY=
 github.com/splitio/go-toolkit/v5 v5.0.3/go.mod h1:K5jrJhC1A5N+JMjPUhMUhxkHExqfDbxLzhGhcZ0Ofd0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/splitio/commitversion.go
+++ b/splitio/commitversion.go
@@ -5,4 +5,4 @@ This file is created automatically, please do not edit
 */
 
 // CommitVersion is the version of the last commit previous to release
-const CommitVersion = "c7a63e1"
+const CommitVersion = "46866c1"

--- a/splitio/commitversion.go
+++ b/splitio/commitversion.go
@@ -5,5 +5,4 @@ This file is created automatically, please do not edit
 */
 
 // CommitVersion is the version of the last commit previous to release
-
-const CommitVersion = "92bfeaf"
+const CommitVersion = "c7a63e1"

--- a/splitio/producer/storage/segment_wrapper.go
+++ b/splitio/producer/storage/segment_wrapper.go
@@ -1,0 +1,141 @@
+package storage
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/splitio/go-split-commons/v4/storage"
+	"github.com/splitio/go-toolkit/v5/datastructures/set"
+	"github.com/splitio/go-toolkit/v5/logging"
+)
+
+// ObservableSegmentStorage builds on top of the SegmentStorage interface adding some observability methods
+type ObservableSegmentStorage interface {
+	storage.SegmentStorage
+	NamesAndCount() map[string]int
+}
+
+// ObservableSegmentStorageImpl is an implementation of the ObservableSegmentStorage interface
+type ObservableSegmentStorageImpl struct {
+	storage.SegmentStorage
+	counter *activeSegmentTracker
+	logger  logging.LoggerInterface
+}
+
+// NewObservableSegmentStorage constructs and observable segment storage
+func NewObservableSegmentStorage(
+	logger logging.LoggerInterface,
+	splitStorage storage.SplitStorage,
+	toWrap storage.SegmentStorage,
+) *ObservableSegmentStorageImpl {
+
+	if _, ok := toWrap.(supportsUpdateWithSummary); !ok {
+		logger.Warning("supplied segment storage doesn't report added/removed counts, this may introduce inconcistencies in observability endpoints")
+	}
+
+	segmentNames := splitStorage.SegmentNames()
+	tracker := newActiveSegmentTracker(segmentNames.Size() + 1)
+
+	if extSS, ok := toWrap.(supportsCardinality); ok {
+		segmentNames.Each(func(i interface{}) bool {
+			strName, ok := i.(string)
+			if !ok {
+				logger.Warning(fmt.Sprintf("non-string segment name fetched: '%+v'//'%T'. This is a bug, please report it.", i, i))
+				return true
+			}
+
+			count, err := extSS.Size(strName)
+			if err != nil {
+				logger.Warning(fmt.Sprintf("failed to get size for segment %s. This may introduce inconsistencies in observability endpoints", strName))
+			}
+
+			tracker.update(strName, count, 0)
+			return true
+		})
+	} else {
+		logger.Warning("storage does not support querying segment size. This may introduce inconsistencies in observability endpoints")
+	}
+
+	return &ObservableSegmentStorageImpl{
+		SegmentStorage: toWrap,
+		counter:        tracker,
+		logger:         logger,
+	}
+}
+
+// Update updates the local segment cache and forwards the call to he underlying storage
+func (s *ObservableSegmentStorageImpl) Update(name string, toAdd *set.ThreadUnsafeSet, toRemove *set.ThreadUnsafeSet, changeNumber int64) error {
+	var added, removed int
+	if rs, ok := s.SegmentStorage.(supportsUpdateWithSummary); ok {
+		var err error
+		added, removed, err = rs.UpdateWithSummary(name, toAdd, toRemove, changeNumber)
+		if err != nil {
+			// TODO(mredolatti): log!
+		}
+	} else {
+		// TODO(mredolatti): is this worth logging? are we just going to annoy people?
+		s.SegmentStorage.Update(name, toAdd, toRemove, changeNumber) // this method doesn't return errors despite it's signature, no need to capture it
+		added = toAdd.Size()
+		removed = toRemove.Size()
+	}
+	s.counter.update(name, added, removed)
+	return nil
+}
+
+// NamesAndCount returns a map of segment names with the number of keys
+func (s *ObservableSegmentStorageImpl) NamesAndCount() map[string]int {
+	return s.counter.namesAndCount()
+}
+
+type activeSegmentTracker struct {
+	activeSegmentMap map[string]int
+	mtx              sync.RWMutex
+}
+
+func newActiveSegmentTracker(initialSize int) *activeSegmentTracker {
+	return &activeSegmentTracker{
+		activeSegmentMap: make(map[string]int, initialSize+1), // to avoid ever constructing a map of size 0
+	}
+}
+
+func (t *activeSegmentTracker) update(name string, added int, removed int) {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
+	current, _ := t.activeSegmentMap[name]
+	current = current + added - removed
+	if current <= 0 {
+		delete(t.activeSegmentMap, name)
+		return
+	}
+	t.activeSegmentMap[name] = current
+}
+
+func (t *activeSegmentTracker) count() int {
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
+	return len(t.activeSegmentMap)
+}
+
+func (t *activeSegmentTracker) namesAndCount() map[string]int {
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
+
+	ret := make(map[string]int, len(t.activeSegmentMap))
+	for name, count := range t.activeSegmentMap {
+		ret[name] = count
+	}
+	return ret
+}
+
+type (
+	supportsUpdateWithSummary interface {
+		UpdateWithSummary(name string, toAdd *set.ThreadUnsafeSet, toRemove *set.ThreadUnsafeSet, till int64) (added int, removed int, err error)
+	}
+
+	supportsCardinality interface {
+		Size(name string) (int, error)
+	}
+)
+
+var _ ObservableSegmentStorage = (*ObservableSegmentStorageImpl)(nil)
+var _ storage.SegmentStorage = (*ObservableSegmentStorageImpl)(nil)

--- a/splitio/producer/storage/segment_wrapper_test.go
+++ b/splitio/producer/storage/segment_wrapper_test.go
@@ -35,7 +35,7 @@ func TestSegmentWrapper(t *testing.T) {
 		SegmentNamesCall: func() *set.ThreadUnsafeSet { return set.NewSet("segment1", "segment2") },
 	}
 
-	observer := NewObservableSegmentStorage(logging.NewLogger(nil), splitStorage, st)
+	observer, _ := NewObservableSegmentStorage(logging.NewLogger(nil), splitStorage, st)
 
 	expected := map[string]int{
 		"segment1": 10,

--- a/splitio/producer/storage/segment_wrapper_test.go
+++ b/splitio/producer/storage/segment_wrapper_test.go
@@ -1,0 +1,133 @@
+package storage
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/splitio/go-split-commons/v4/storage/mocks"
+	"github.com/splitio/go-toolkit/v5/datastructures/set"
+	"github.com/splitio/go-toolkit/v5/logging"
+)
+
+func TestSegmentWrapper(t *testing.T) {
+	st := &extMockSegmentStorage{
+		MockSegmentStorage: &mocks.MockSegmentStorage{
+			UpdateCall: func(name string, toAdd *set.ThreadUnsafeSet, toRemove *set.ThreadUnsafeSet, till int64) error {
+				t.Error("should not be called!")
+				return nil
+			},
+		},
+		SizeCall: func(name string) (int, error) {
+			switch name {
+			case "segment1":
+				return 10, nil
+			case "segment2":
+				return 20, nil
+			}
+			return 0, nil
+		},
+		UpdateWithSummaryCall: func(string, *set.ThreadUnsafeSet, *set.ThreadUnsafeSet, int64) (int, int, error) {
+			return 0, 0, nil
+		},
+	}
+
+	splitStorage := &mocks.MockSplitStorage{
+		SegmentNamesCall: func() *set.ThreadUnsafeSet { return set.NewSet("segment1", "segment2") },
+	}
+
+	observer := NewObservableSegmentStorage(logging.NewLogger(nil), splitStorage, st)
+
+	expected := map[string]int{
+		"segment1": 10,
+		"segment2": 20,
+	}
+
+	if !reflect.DeepEqual(expected, observer.NamesAndCount()) {
+		t.Error("names and count doesn't match expected")
+	}
+
+	expected["segment3"] = 3
+	st.UpdateWithSummaryCall = func(string, *set.ThreadUnsafeSet, *set.ThreadUnsafeSet, int64) (int, int, error) { return 3, 0, nil }
+	observer.Update("segment3", set.NewSet("k1", "k2", "k3"), set.NewSet(), 123)
+	if !reflect.DeepEqual(expected, observer.NamesAndCount()) {
+		t.Error("names and count doesn't match expected")
+	}
+
+	delete(expected, "segment3")
+	st.UpdateWithSummaryCall = func(string, *set.ThreadUnsafeSet, *set.ThreadUnsafeSet, int64) (int, int, error) { return 0, 3, nil }
+	observer.Update("segment3", set.NewSet(), set.NewSet("k1", "k2", "k3"), 123)
+	if !reflect.DeepEqual(expected, observer.NamesAndCount()) {
+		t.Error("names and count doesn't match expected")
+	}
+
+	expected["segment2"] = 22
+	st.UpdateWithSummaryCall = func(string, *set.ThreadUnsafeSet, *set.ThreadUnsafeSet, int64) (int, int, error) { return 3, 1, nil }
+	observer.Update("segment2", set.NewSet("k1", "k2", "k3"), set.NewSet("k4"), 123)
+	if !reflect.DeepEqual(expected, observer.NamesAndCount()) {
+		t.Error("names and count doesn't match expected")
+	}
+
+	delete(expected, "segment1")
+	st.UpdateWithSummaryCall = func(string, *set.ThreadUnsafeSet, *set.ThreadUnsafeSet, int64) (int, int, error) { return 0, 10, nil }
+	observer.Update("segment1", set.NewSet(), set.NewSet("k1", "k2", "k3", "k4", "k5", "k6", "k7", "k8", "k9", "k10"), 123)
+	if !reflect.DeepEqual(expected, observer.NamesAndCount()) {
+		t.Error("names and count doesn't match expected")
+	}
+}
+
+func TestActiveSegmentTracker(t *testing.T) {
+
+	expected := map[string]int{
+		"segment1": 50,
+		"segment2": 40,
+		"segment3": 30,
+	}
+
+	trk := newActiveSegmentTracker(10)
+	trk.update("segment1", 50, 0)
+	trk.update("segment2", 40, 0)
+	trk.update("segment3", 30, 0)
+	if trk.count() != 3 {
+		t.Error("there should be 3 segments cached")
+	}
+
+	if !reflect.DeepEqual(expected, trk.namesAndCount()) {
+		t.Error("current status doens't match expected")
+	}
+
+	trk.update("segment4", 0, 300)
+	if !reflect.DeepEqual(expected, trk.namesAndCount()) {
+		t.Error("current status doens't match expected")
+	}
+
+	trk.update("segment1", 0, 49)
+	expected["segment1"] = 1
+	if !reflect.DeepEqual(expected, trk.namesAndCount()) {
+		t.Error("current status doens't match expected")
+	}
+
+	trk.update("segment1", 0, 1)
+	delete(expected, "segment1")
+	if !reflect.DeepEqual(expected, trk.namesAndCount()) {
+		t.Error("current status doens't match expected")
+	}
+
+	if trk.count() != 2 {
+		t.Error("there should be 2 elements now")
+	}
+
+}
+
+type extMockSegmentStorage struct {
+	*mocks.MockSegmentStorage
+	UpdateWithSummaryCall func(string, *set.ThreadUnsafeSet, *set.ThreadUnsafeSet, int64) (int, int, error)
+	SizeCall              func(string) (int, error)
+}
+
+func (e *extMockSegmentStorage) UpdateWithSummary(name string, toAdd *set.ThreadUnsafeSet, toRemove *set.ThreadUnsafeSet, till int64) (added int, removed int, err error) {
+	return e.UpdateWithSummaryCall(name, toAdd, toRemove, till)
+}
+
+func (e *extMockSegmentStorage) Size(name string) (int, error) {
+	return e.SizeCall(name)
+}

--- a/splitio/producer/storage/split_wrapper.go
+++ b/splitio/producer/storage/split_wrapper.go
@@ -1,0 +1,153 @@
+package storage
+
+import (
+	"sync"
+
+	"github.com/splitio/go-split-commons/v4/dtos"
+	"github.com/splitio/go-split-commons/v4/storage"
+	"github.com/splitio/go-split-commons/v4/storage/redis"
+	"github.com/splitio/go-toolkit/v5/logging"
+)
+
+// ObservableSplitStorage is an interface extender that adds the method `Count` to the split storage
+type ObservableSplitStorage interface {
+	storage.SplitStorage
+	Count() int
+	Names() []string
+}
+
+// ObservableSplitStorageImpl is an implementaion of the ObservableSplitStorage inteface that wraps an existing storage
+// caches and caches splitnames in-memory (in case the underlying one is non-local, ie: redis)
+type ObservableSplitStorageImpl struct {
+	storage.SplitStorage
+	active *activeSplitTracker
+}
+
+// NewObservableSplitStorage constructs a NewObservableSplitStorage
+func NewObservableSplitStorage(toWrap storage.SplitStorage, logger logging.LoggerInterface) *ObservableSplitStorageImpl {
+
+	names := toWrap.SplitNames()
+	active := newActiveSplitTracker(len(names))
+	active.update(names, nil)
+
+	if _, ok := toWrap.(supportsUpdateWithErrors); !ok {
+		logger.Warning("supplied split storage doesn't report errors, this may introduce inconcistencies in observability endpoints")
+	}
+
+	return &ObservableSplitStorageImpl{
+		SplitStorage: toWrap,
+		active:       active,
+	}
+}
+
+// Update is an override that wraps the original Update method and calls update on the local cache as well
+func (s *ObservableSplitStorageImpl) Update(toAdd []dtos.SplitDTO, toRemove []dtos.SplitDTO, changeNumber int64) {
+	if rs, ok := s.SplitStorage.(supportsUpdateWithErrors); ok {
+		if err := rs.UpdateWithErrors(toAdd, toRemove, changeNumber); err != nil {
+			switch parsedErr := err.(type) {
+			case nil:
+				// no error
+			case *redis.UpdateError:
+				toAdd = filterFailed(toAdd, parsedErr.FailedToAdd)
+				toRemove = filterFailed(toRemove, parsedErr.FailedToRemove)
+			default:
+				// Other types of error are considered critical, meaning nothing got updated,
+				// hence our cache should not be updated as well
+				return
+			}
+		}
+	} else {
+		// TODO(mredolatti): is this worth logging? are we just going to annoy people?
+		s.SplitStorage.Update(toAdd, toRemove, changeNumber)
+	}
+	s.active.update(splitNames(toAdd), splitNames(toRemove))
+}
+
+// Count returns the number of active splits
+func (s *ObservableSplitStorageImpl) Count() int {
+	return s.active.count()
+}
+
+// Names returns a list of cached splits
+func (s *ObservableSplitStorageImpl) Names() []string {
+	return s.active.names()
+}
+
+type activeSplitTracker struct {
+	activeSplitMap map[string]struct{}
+	mtx            sync.RWMutex
+}
+
+func newActiveSplitTracker(initialSize int) *activeSplitTracker {
+	return &activeSplitTracker{
+		activeSplitMap: make(map[string]struct{}, initialSize+1), // to avoid ever constructing a map of size 0
+	}
+}
+
+func (t *activeSplitTracker) update(toAdd []string, toRemove []string) {
+	t.mtx.Lock()
+	for _, name := range toAdd {
+		t.activeSplitMap[name] = struct{}{}
+	}
+
+	for _, name := range toRemove {
+		delete(t.activeSplitMap, name)
+	}
+	t.mtx.Unlock()
+}
+
+func (t *activeSplitTracker) count() int {
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
+	return len(t.activeSplitMap)
+}
+
+func (t *activeSplitTracker) names() []string {
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
+
+	ret := make([]string, 0, len(t.activeSplitMap))
+	for name := range t.activeSplitMap {
+		ret = append(ret, name)
+	}
+	return ret
+}
+
+func splitNames(splits []dtos.SplitDTO) []string {
+	names := make([]string, 0, len(splits))
+	for idx := range splits {
+		names = append(names, splits[idx].Name)
+	}
+	return names
+}
+
+func filterFailed(in []dtos.SplitDTO, failed map[string]error) []dtos.SplitDTO {
+	if len(failed) == 0 {
+		return in
+	}
+
+	idx := 0
+	newSliceEnd := len(in)
+	for idx < newSliceEnd {
+		if _, ok := failed[in[idx].Name]; !ok {
+			// If this item isn't a failed one, keep going
+			idx++
+			continue
+		}
+
+		// Otherwise, replace it with the last one and shrink the size of the slice
+		// idx is not updated since the previously-last element might also be a failed one, so needs to be checked
+		// in the next iteration...
+		newSliceEnd--
+		in[idx] = in[newSliceEnd]
+	}
+
+	return in[:newSliceEnd]
+}
+
+type supportsUpdateWithErrors interface {
+	UpdateWithErrors(toAdd []dtos.SplitDTO, toRemove []dtos.SplitDTO, changeNumber int64) error
+}
+
+var _ ObservableSplitStorage = (*ObservableSplitStorageImpl)(nil)
+var _ storage.SplitStorage = (*ObservableSplitStorageImpl)(nil)

--- a/splitio/producer/storage/split_wrapper_test.go
+++ b/splitio/producer/storage/split_wrapper_test.go
@@ -94,4 +94,4 @@ func (e *extMockSplitStorage) UpdateWithErrors(toAdd []dtos.SplitDTO, toRemove [
 	return e.UpdateWithErrorsCall(toAdd, toRemove, cn)
 }
 
-var _ supportsUpdateWithErrors = (*extMockSplitStorage)(nil)
+var _ extendedSplitStorage = (*extMockSplitStorage)(nil)

--- a/splitio/producer/storage/split_wrapper_test.go
+++ b/splitio/producer/storage/split_wrapper_test.go
@@ -23,7 +23,7 @@ func TestSplitWrapper(t *testing.T) {
 		nil,
 	}
 
-	observer := NewObservableSplitStorage(st, logging.NewLogger(nil))
+	observer, _ := NewObservableSplitStorage(st, logging.NewLogger(nil))
 	if c := observer.Count(); c != 2 {
 		t.Error("count sohuld be 2. Is ", c)
 	}

--- a/splitio/producer/storage/split_wrapper_test.go
+++ b/splitio/producer/storage/split_wrapper_test.go
@@ -1,0 +1,97 @@
+package storage
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/splitio/go-split-commons/v4/dtos"
+	"github.com/splitio/go-split-commons/v4/storage/mocks"
+	"github.com/splitio/go-split-commons/v4/storage/redis"
+	"github.com/splitio/go-toolkit/v5/logging"
+)
+
+func TestSplitWrapper(t *testing.T) {
+	st := &extMockSplitStorage{
+		&mocks.MockSplitStorage{
+			SplitNamesCall: func() []string {
+				return []string{"split1", "split2"}
+			},
+			UpdateCall: func([]dtos.SplitDTO, []dtos.SplitDTO, int64) {
+				t.Error("should not be called")
+			},
+		},
+		nil,
+	}
+
+	observer := NewObservableSplitStorage(st, logging.NewLogger(nil))
+	if c := observer.Count(); c != 2 {
+		t.Error("count sohuld be 2. Is ", c)
+	}
+
+	// split4 should fail to be updated
+	st.UpdateWithErrorsCall = func(toAdd []dtos.SplitDTO, toRemove []dtos.SplitDTO, cn int64) error {
+		return &redis.UpdateError{
+			FailedToAdd: map[string]error{"split4": errors.New("something")},
+		}
+	}
+	observer.Update([]dtos.SplitDTO{{Name: "split3"}, {Name: "split4"}}, []dtos.SplitDTO{}, 1)
+	if _, ok := observer.active.activeSplitMap["split3"]; !ok {
+		t.Error("split3 should be cached")
+	}
+	if _, ok := observer.active.activeSplitMap["split4"]; ok {
+		t.Error("split4 should not be cached")
+	}
+}
+
+var errSome = errors.New("some random error")
+
+func TestActiveSplitTracker(t *testing.T) {
+	trk := newActiveSplitTracker(10)
+	trk.update([]string{"split1", "split2"}, []string{"nonexistant"})
+	n := trk.names()
+	if len(n) != 2 || trk.count() != 2 {
+		t.Error("there should be 2 elements")
+	}
+
+	trk.update(nil, []string{"split2"})
+	if trk.names()[0] != "split1" {
+		t.Error("there should be only one element 'split1'")
+	}
+
+	trk.update(nil, []string{"split1"})
+	if len(trk.names()) != 0 || trk.count() != 0 {
+		t.Error("there should be 0 items")
+	}
+}
+
+func TestFilterFailed(t *testing.T) {
+	splits := []dtos.SplitDTO{{Name: "split1"}, {Name: "split2"}, {Name: "split3"}, {Name: "split4"}}
+	failed := map[string]error{
+		"split2": errSome,
+		"split4": errSome,
+	}
+
+	withoutFailed := filterFailed(splits, failed)
+	if l := len(withoutFailed); l != 2 {
+		t.Error("there should be 2 items after removing the failed ones. Have: ", l)
+		t.Error(withoutFailed)
+	}
+
+	if n := withoutFailed[0].Name; n != "split1" {
+		t.Error("first one should be 'split1'. is: ", n)
+	}
+	if n := withoutFailed[1].Name; n != "split3" {
+		t.Error("first one should be 'split1'. is: ", n)
+	}
+}
+
+type extMockSplitStorage struct {
+	*mocks.MockSplitStorage
+	UpdateWithErrorsCall func([]dtos.SplitDTO, []dtos.SplitDTO, int64) error
+}
+
+func (e *extMockSplitStorage) UpdateWithErrors(toAdd []dtos.SplitDTO, toRemove []dtos.SplitDTO, cn int64) error {
+	return e.UpdateWithErrorsCall(toAdd, toRemove, cn)
+}
+
+var _ supportsUpdateWithErrors = (*extMockSplitStorage)(nil)

--- a/splitio/version.go
+++ b/splitio/version.go
@@ -2,4 +2,4 @@
 package splitio
 
 // Version is the version of this Agent
-const Version = "5.0.2"
+const Version = "5.0.3-rc1"


### PR DESCRIPTION
Add wrappers to split & segment storages incorporating caches that get populated at construction time and updated automatically. At the same time they expose methods for observability purposes (list of available spllits, list of segments & #keys)