### PR TITLE
Feat/historic telemetry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gin-gonic/gin v1.7.7
 	github.com/google/uuid v1.3.0
 	github.com/splitio/gincache v0.0.1-rc7
-	github.com/splitio/go-split-commons/v4 v4.0.3-rc1
+	github.com/splitio/go-split-commons/v4 v4.0.3-rc3
 	github.com/splitio/go-toolkit/v5 v5.0.3
 	go.etcd.io/bbolt v1.3.6
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/splitio/gincache v0.0.1-rc7 h1:BNIP3uaT4zqRepYwi6TRJevzPX3EsgUnLSA3nwNu5tw=
 github.com/splitio/gincache v0.0.1-rc7/go.mod h1:IUKPDIlTSH8bNqpgMDWjgrbbkqhApnQHSxXp5uKjGg8=
-github.com/splitio/go-split-commons/v4 v4.0.3-rc1 h1:o8cWCgCwjqDGTD+FdcxKjwkWztJQ/LUjuAnuxttfKRY=
-github.com/splitio/go-split-commons/v4 v4.0.3-rc1/go.mod h1:42zur2Zsz0Y6aQ3r5Zmqkhq6/vlNF56B9BXW+QpIEeo=
+github.com/splitio/go-split-commons/v4 v4.0.3-rc3 h1:2atOr+gngcYBRkJguExVvdaT0KCaOAj8WPU+uWEs47o=
+github.com/splitio/go-split-commons/v4 v4.0.3-rc3/go.mod h1:42zur2Zsz0Y6aQ3r5Zmqkhq6/vlNF56B9BXW+QpIEeo=
 github.com/splitio/go-toolkit/v5 v5.0.3 h1:3LrhJo76ZYTsi/cWS2pDfH6+ImKlOqtp3J98qm4WGpY=
 github.com/splitio/go-toolkit/v5 v5.0.3/go.mod h1:K5jrJhC1A5N+JMjPUhMUhxkHExqfDbxLzhGhcZ0Ofd0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/splitio/commitversion.go
+++ b/splitio/commitversion.go
@@ -5,4 +5,4 @@ This file is created automatically, please do not edit
 */
 
 // CommitVersion is the version of the last commit previous to release
-const CommitVersion = "4e77d75"
+const CommitVersion = "b946dc0"

--- a/splitio/commitversion.go
+++ b/splitio/commitversion.go
@@ -5,4 +5,4 @@ This file is created automatically, please do not edit
 */
 
 // CommitVersion is the version of the last commit previous to release
-const CommitVersion = "46866c1"
+const CommitVersion = "4e77d75"

--- a/splitio/proxy/storage/telemetry.go
+++ b/splitio/proxy/storage/telemetry.go
@@ -209,7 +209,7 @@ type ProxyEndpointLatenciesImpl struct {
 
 // RecordEndpointLatency records a (bucketed) latency for a specific endpoint
 func (p *ProxyEndpointLatenciesImpl) RecordEndpointLatency(endpoint int, latency time.Duration) {
-	bucket := telemetry.Bucket(latency.Microseconds())
+	bucket := telemetry.Bucket(latency.Milliseconds())
 	switch endpoint {
 	case AuthEndpoint:
 		p.auth.Incr(bucket)

--- a/splitio/proxy/storage/telemetry.go
+++ b/splitio/proxy/storage/telemetry.go
@@ -209,7 +209,7 @@ type ProxyEndpointLatenciesImpl struct {
 
 // RecordEndpointLatency records a (bucketed) latency for a specific endpoint
 func (p *ProxyEndpointLatenciesImpl) RecordEndpointLatency(endpoint int, latency time.Duration) {
-	bucket := telemetry.Bucket(latency.Milliseconds())
+	bucket := telemetry.Bucket(latency.Microseconds())
 	switch endpoint {
 	case AuthEndpoint:
 		p.auth.Incr(bucket)

--- a/splitio/proxy/storage/telemetryts.go
+++ b/splitio/proxy/storage/telemetryts.go
@@ -1,0 +1,227 @@
+package storage
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+// Granularity selection constants to be used upon component instantiation
+const (
+	HistoricTelemetryGranularityMinute = iota
+	HistoricTelemetryGranularityHour
+	HistoricTelemetryGranularityDay
+)
+
+type telemetryByTimeSlice map[int64]*timeSliceTelemetry
+
+// TimeslicedProxyEndpointTelemetry is a proxy telemetry facade (yet another) that bundles global data
+// and historic data by timeslice (for observability purposes)
+type TimeslicedProxyEndpointTelemetry interface {
+	ProxyEndpointTelemetry
+	TimeslicedReport() TimeSliceData
+}
+
+// TimeslicedProxyEndpointTelemetryImpl is an implementation of `TimeslicedProxyEnxpointTelemetry`
+type TimeslicedProxyEndpointTelemetryImpl struct {
+	accum                ProxyEndpointTelemetry
+	telemetryByTimeSlice telemetryByTimeSlice
+	timeSliceWidth       int64
+	maxTimeSlices        int
+	mutex                sync.Mutex
+	clock                clock // this is just to be able to mock the time and do proper unit testing
+}
+
+// NewTimeslicedProxyEndpointTelemetry constructs a new timesliced proxy-endpoint telemetry
+func NewTimeslicedProxyEndpointTelemetry(wrapped ProxyEndpointTelemetry, width int64, maxTimeSlices int) *TimeslicedProxyEndpointTelemetryImpl {
+	return &TimeslicedProxyEndpointTelemetryImpl{
+		accum:                wrapped,
+		telemetryByTimeSlice: make(telemetryByTimeSlice),
+		timeSliceWidth:       width,
+		maxTimeSlices:        maxTimeSlices,
+		clock:                &sysClock{},
+	}
+}
+
+// TimeslicedReport returns a report of the latest metrics split into N time-slices
+func (t *TimeslicedProxyEndpointTelemetryImpl) TimeslicedReport() TimeSliceData {
+	// gather the data
+	t.mutex.Lock()
+	data := make([]*timeSliceTelemetry, 0, len(t.telemetryByTimeSlice))
+	for _, v := range t.telemetryByTimeSlice {
+		if v != nil { // should always be true but still...
+			data = append(data, v)
+		}
+	}
+	t.mutex.Unlock()
+
+	// format & return
+	return formatTimeSeriesData(data)
+}
+
+// PeekEndpointLatency returns the endpoint latencies for a specific resource (global only)
+func (t *TimeslicedProxyEndpointTelemetryImpl) PeekEndpointLatency(resource int) []int64 {
+	return t.accum.PeekEndpointLatency(resource)
+}
+
+// PeekEndpointStatus returns the global endpoint status codes for a specific resource (global only)
+func (t *TimeslicedProxyEndpointTelemetryImpl) PeekEndpointStatus(resource int) map[int]int64 {
+	return t.accum.PeekEndpointStatus(resource)
+}
+
+// RecordEndpointLatency increments the latency bucket for a specific endpoint (global + historic records are updated)
+func (t *TimeslicedProxyEndpointTelemetryImpl) RecordEndpointLatency(endpoint int, latency time.Duration) {
+	t.accum.RecordEndpointLatency(endpoint, latency)
+	timesliced := t.geHistoricForTS(t.clock.Now())
+	timesliced.latencies.RecordEndpointLatency(endpoint, latency)
+}
+
+// IncrEndpointStatus increments the status code count for a specific endpont/status code (global + historic records are updated)
+func (t *TimeslicedProxyEndpointTelemetryImpl) IncrEndpointStatus(endpoint int, status int) {
+	t.accum.IncrEndpointStatus(endpoint, status)
+	timesliced := t.geHistoricForTS(t.clock.Now())
+	timesliced.statusCodes.IncrEndpointStatus(endpoint, status)
+}
+
+func (t *TimeslicedProxyEndpointTelemetryImpl) geHistoricForTS(ts time.Time) *timeSliceTelemetry {
+	timeSlice := keyForTimeSlice(ts, t.timeSliceWidth)
+
+	// The following critical section guards access to the timeslice -> telemetry map AND
+	// the rollover mechanism if a new entry is created and the count is greater than the allowed max.
+	// `EndpointStatusCodes & `ProxyEndpointLatencies` structs have their own synchronization mechanisms
+	// and are safe to use by the the reference is returned
+	t.mutex.Lock()
+	current, ok := t.telemetryByTimeSlice[timeSlice]
+	if !ok {
+		current = newTimeSliceTelemetry(timeSlice)
+		t.telemetryByTimeSlice[timeSlice] = current
+		if len(t.telemetryByTimeSlice) > t.maxTimeSlices {
+			t.unsafeRollover()
+		}
+	}
+	t.mutex.Unlock()
+	return current
+}
+
+// warning: This method is meant to be called from `getHistoricForTS` whenever needed WITH THE LOCK ACQUIRED. Otherwise it may crash the app
+func (t *TimeslicedProxyEndpointTelemetryImpl) unsafeRollover() {
+	if len(t.telemetryByTimeSlice) <= t.maxTimeSlices {
+		return // we're within boundaries, nothing to do here
+	}
+
+	keys := make([]int64, 0, len(t.telemetryByTimeSlice))
+	for key := range t.telemetryByTimeSlice {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+
+	for _, key := range keys[0:(len(keys) - t.maxTimeSlices)] { // narrow view of the slice only contain older elements to be deleted
+		delete(t.telemetryByTimeSlice, key)
+	}
+}
+
+type timeSliceTelemetry struct {
+	timeSlice   int64
+	statusCodes EndpointStatusCodes
+	latencies   ProxyEndpointLatenciesImpl
+}
+
+func newTimeSliceTelemetry(timeSlice int64) *timeSliceTelemetry {
+	return &timeSliceTelemetry{
+		timeSlice:   timeSlice,
+		statusCodes: newEndpointStatusCodes(),
+		latencies:   newProxyEndpointLatenciesImpl(), // TODO(mredolatti): in the future, check why this is not returning a pointer
+	}
+}
+
+func keyForTimeSlice(t time.Time, intervalWidthInSeconds int64) int64 {
+	curr := t.Unix()
+	return curr - (curr % intervalWidthInSeconds)
+}
+
+// TimeSliceData splits the latest metrics in N entries of fixed x-seconds width timeslices
+type TimeSliceData []map[string]ForResource
+
+// ForResource bundles latencies & status code for a specific timeslice
+type ForResource struct {
+	TimeSlice   int64         `json:"timeslice"`
+	Latencies   []int64       `json:"latencies"`
+	StatusCodes map[int]int64 `json:"statusCodes"`
+}
+
+func formatTimeSeriesData(data []*timeSliceTelemetry) TimeSliceData {
+	sort.Slice(data, func(i, j int) bool { return data[i].timeSlice < data[j].timeSlice })
+	toRet := make(TimeSliceData, 0, len(data))
+	for _, ts := range data {
+		forTS := map[string]ForResource{
+			"auth": ForResource{
+				TimeSlice:   ts.timeSlice,
+				Latencies:   ts.latencies.auth.ReadAll(),
+				StatusCodes: ts.statusCodes.auth.peek(),
+			},
+			"splitChanges": ForResource{
+				TimeSlice:   ts.timeSlice,
+				Latencies:   ts.latencies.splitChanges.ReadAll(),
+				StatusCodes: ts.statusCodes.splitChanges.peek(),
+			},
+			"segmentChanges": ForResource{
+				TimeSlice:   ts.timeSlice,
+				Latencies:   ts.latencies.segmentChanges.ReadAll(),
+				StatusCodes: ts.statusCodes.segmentChanges.peek(),
+			},
+			"impressionsBulk": ForResource{
+				TimeSlice:   ts.timeSlice,
+				Latencies:   ts.latencies.impressionsBulk.ReadAll(),
+				StatusCodes: ts.statusCodes.impressionsBulk.peek(),
+			},
+			"impressionsBulkBeacon": ForResource{
+				TimeSlice:   ts.timeSlice,
+				Latencies:   ts.latencies.impressionsBulkBeacon.ReadAll(),
+				StatusCodes: ts.statusCodes.impressionsBulkBeacon.peek(),
+			},
+			"impressionsCount": ForResource{
+				TimeSlice:   ts.timeSlice,
+				Latencies:   ts.latencies.impressionsCount.ReadAll(),
+				StatusCodes: ts.statusCodes.impressionsCount.peek(),
+			},
+			"impressionsCountBeacon": ForResource{
+				TimeSlice:   ts.timeSlice,
+				Latencies:   ts.latencies.impressionsCountBeacon.ReadAll(),
+				StatusCodes: ts.statusCodes.impressionsCountBeacon.peek(),
+			},
+			"eventsBulk": ForResource{
+				TimeSlice:   ts.timeSlice,
+				Latencies:   ts.latencies.eventsBulk.ReadAll(),
+				StatusCodes: ts.statusCodes.eventsBulk.peek(),
+			},
+			"eventsBulkBeacon": ForResource{
+				TimeSlice:   ts.timeSlice,
+				Latencies:   ts.latencies.eventsBulkBeacon.ReadAll(),
+				StatusCodes: ts.statusCodes.eventsBulkBeacon.peek(),
+			},
+			"telemetryConfig": ForResource{
+				TimeSlice:   ts.timeSlice,
+				Latencies:   ts.latencies.telemetryConfig.ReadAll(),
+				StatusCodes: ts.statusCodes.telemetryConfig.peek(),
+			},
+			"telemetryRuntime": ForResource{
+				TimeSlice:   ts.timeSlice,
+				Latencies:   ts.latencies.telemetryRuntime.ReadAll(),
+				StatusCodes: ts.statusCodes.telemetryRuntime.peek(),
+			},
+		}
+		toRet = append(toRet, forTS)
+	}
+	return toRet
+}
+
+// clock interface for mocking
+type clock interface {
+	Now() time.Time
+}
+
+type sysClock struct{}
+
+func (c *sysClock) Now() time.Time { return time.Now() }
+
+var _ TimeslicedProxyEndpointTelemetry = (*TimeslicedProxyEndpointTelemetryImpl)(nil)

--- a/splitio/proxy/storage/telemetryts_test.go
+++ b/splitio/proxy/storage/telemetryts_test.go
@@ -1,0 +1,109 @@
+package storage
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+type mockClock struct {
+	base  time.Time
+	count int
+}
+
+func (c *mockClock) Now() time.Time {
+	c.count++
+	return c.base.Add(time.Duration(c.count) * time.Millisecond)
+}
+
+func TestHistoricProxyTelemetry(t *testing.T) {
+	clk := mockClock{base: time.Now()}
+	toWrap := NewProxyTelemetryFacade()
+	timesliced := NewTimeslicedProxyEndpointTelemetry(toWrap, 60, 5)
+	timesliced.clock = &clk
+
+	endpoints := []int{
+		AuthEndpoint,
+		SplitChangesEndpoint,
+		SegmentChangesEndpoint,
+		ImpressionsBulkEndpoint,
+		ImpressionsBulkBeaconEndpoint,
+		ImpressionsCountEndpoint,
+		ImpressionsCountBeaconEndpoint,
+		EventsBulkEndpoint,
+		EventsBulkBeaconEndpoint,
+		TelemetryConfigEndpoint,
+		TelemetryRuntimeEndpoint,
+	}
+
+	oldestTs := keyForTimeSlice(clk.base, 60) // store the oldest timeslice, so we can see it's no longet present after eviction
+	for idx := 0; idx < 5; idx++ {
+		// add metrics to endpoints
+		for _, endpoint := range endpoints {
+			timesliced.RecordEndpointLatency(endpoint, 1*time.Nanosecond) // put a one on the FIRST slot of each latency bucket array
+			timesliced.RecordEndpointLatency(endpoint, 5*time.Hour)       // put a one on the LAST slot of each latency bucket array
+			timesliced.IncrEndpointStatus(endpoint, 200)                  // add a successful call
+			timesliced.IncrEndpointStatus(endpoint, 500)                  // add a failed call
+		}
+		clk.base = clk.base.Add(60 * time.Second)
+	}
+
+	if len(timesliced.telemetryByTimeSlice) != 5 {
+		t.Error("there should be records in 5 timeslices")
+	}
+
+	if _, ok := timesliced.telemetryByTimeSlice[oldestTs]; !ok {
+		t.Error("the oldest TS shuoldn't have been evicted yet")
+	}
+
+	// add a 6th timeslice (oldest should be cropped out)
+	for _, endpoint := range endpoints {
+		timesliced.RecordEndpointLatency(endpoint, 1*time.Nanosecond) // put a one on the FIRST slot of each latency bucket array
+		timesliced.RecordEndpointLatency(endpoint, 1*time.Hour)       // put a one on the LAST slot of each latency bucket array
+		timesliced.IncrEndpointStatus(endpoint, 200)                  // add a successful call
+		timesliced.IncrEndpointStatus(endpoint, 500)                  // add a failed call
+	}
+
+	if len(timesliced.telemetryByTimeSlice) != 5 {
+		t.Error("there should be records in 5 timeslices")
+	}
+
+	if _, ok := timesliced.telemetryByTimeSlice[oldestTs]; ok {
+		t.Error("the oldest TS shuoldn have been evicted after adding the 6th timeslice")
+	}
+
+	// manually build the expected report and check it against the generated one
+	expectedStatusCodes := map[int]int64{200: 1, 500: 1}
+	expectedLatencies := []int64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+	expectedTimeSlices := []int64{oldestTs + 60, oldestTs + 120, oldestTs + 180, oldestTs + 240, oldestTs + 300}
+	expectedData := []map[string]ForResource{}
+	for _, ts := range expectedTimeSlices {
+		expectedData = append(expectedData, map[string]ForResource{
+			"auth":                   ForResource{ts, expectedLatencies, expectedStatusCodes},
+			"splitChanges":           ForResource{ts, expectedLatencies, expectedStatusCodes},
+			"segmentChanges":         ForResource{ts, expectedLatencies, expectedStatusCodes},
+			"impressionsBulk":        ForResource{ts, expectedLatencies, expectedStatusCodes},
+			"impressionsBulkBeacon":  ForResource{ts, expectedLatencies, expectedStatusCodes},
+			"impressionsCount":       ForResource{ts, expectedLatencies, expectedStatusCodes},
+			"impressionsCountBeacon": ForResource{ts, expectedLatencies, expectedStatusCodes},
+			"eventsBulk":             ForResource{ts, expectedLatencies, expectedStatusCodes},
+			"eventsBulkBeacon":       ForResource{ts, expectedLatencies, expectedStatusCodes},
+			"telemetryConfig":        ForResource{ts, expectedLatencies, expectedStatusCodes},
+			"telemetryRuntime":       ForResource{ts, expectedLatencies, expectedStatusCodes},
+		})
+	}
+
+	generated := timesliced.TimeslicedReport()
+	if lgen, lexp := len(generated), len(expectedData); lgen != lexp {
+		t.Error("generated & expected have different lengths: ", lgen, lexp)
+		return // to avoid panicking on the test below
+	}
+
+	for idx := range generated {
+		if !reflect.DeepEqual(generated[idx], expectedData[idx]) {
+			t.Errorf("index: %d - generated & expected data don't match", idx)
+			t.Errorf("generated: %+v", generated[idx])
+			t.Errorf("expected: %+v", expectedData[idx])
+		}
+	}
+}


### PR DESCRIPTION
This feature adds support for historic telemetry recording and querying in-memory for split-proxy.
This component accepts a timeslice width (in seconds) and a maximum number of timeslices to keep in memory (the older will be purged as new ones are added).

Now, latencies & status code (which also allow derivation of successful, failed & total requests counts) per endpoint  are made available for the last N timeslices. This data will then be feed to the soon to be added observability endpoint.

Data returned by the component  (NOT final JSON that will be rendered in the endpoint's response) currently looks like this:
```
[
   { // timeslice 1
        <resource_a>: {
            status: {
                <code>:  <count>,
                ...
            },
            latency: [<bucket1_count>, ..., <bucket_n_count>]
        },
        <resource_b>: {
            status: {
                <code>:  <count>,
                ...
            },
            latency: [<bucket1_count>, ..., <bucket_n_count>]
        },
    },
    { // timeslice 2
    ...
     }
}
```