### PR TITLE
fix dashboard for split-proxy, broken after adding time-sliced telemetry

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+5.0.4 (Apr 20, 2022)
+ - Fix dashboard in proxy mode
+
 5.0.3 (Apr 18, 2022)
  - Fix logging config
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 5.0.4 (Apr 20, 2022)
  - Fix dashboard in proxy mode
+ - Fetch telemetry from redis keys in both old & new formats
 
 5.0.3 (Apr 18, 2022)
  - Fix logging config

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gin-gonic/gin v1.7.7
 	github.com/google/uuid v1.3.0
 	github.com/splitio/gincache v0.0.1-rc7
-	github.com/splitio/go-split-commons/v4 v4.0.3
+	github.com/splitio/go-split-commons/v4 v4.0.4-rc2
 	github.com/splitio/go-toolkit/v5 v5.0.3
 	go.etcd.io/bbolt v1.3.6
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gin-gonic/gin v1.7.7
 	github.com/google/uuid v1.3.0
 	github.com/splitio/gincache v0.0.1-rc7
-	github.com/splitio/go-split-commons/v4 v4.0.4-rc2
+	github.com/splitio/go-split-commons/v4 v4.0.4
 	github.com/splitio/go-toolkit/v5 v5.0.3
 	go.etcd.io/bbolt v1.3.6
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/splitio/gincache v0.0.1-rc7 h1:BNIP3uaT4zqRepYwi6TRJevzPX3EsgUnLSA3nwNu5tw=
 github.com/splitio/gincache v0.0.1-rc7/go.mod h1:IUKPDIlTSH8bNqpgMDWjgrbbkqhApnQHSxXp5uKjGg8=
-github.com/splitio/go-split-commons/v4 v4.0.3 h1:FVxu/Vs++pGbeOgYJQomghPy75gtv3FxKcqfTp5g7UM=
-github.com/splitio/go-split-commons/v4 v4.0.3/go.mod h1:42zur2Zsz0Y6aQ3r5Zmqkhq6/vlNF56B9BXW+QpIEeo=
+github.com/splitio/go-split-commons/v4 v4.0.4-rc2 h1:I1h3KqnAq4xTs2ld7iGZ6/aED7In83WQIU7n2LcF7vQ=
+github.com/splitio/go-split-commons/v4 v4.0.4-rc2/go.mod h1:42zur2Zsz0Y6aQ3r5Zmqkhq6/vlNF56B9BXW+QpIEeo=
 github.com/splitio/go-toolkit/v5 v5.0.3 h1:3LrhJo76ZYTsi/cWS2pDfH6+ImKlOqtp3J98qm4WGpY=
 github.com/splitio/go-toolkit/v5 v5.0.3/go.mod h1:K5jrJhC1A5N+JMjPUhMUhxkHExqfDbxLzhGhcZ0Ofd0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/splitio/gincache v0.0.1-rc7 h1:BNIP3uaT4zqRepYwi6TRJevzPX3EsgUnLSA3nwNu5tw=
 github.com/splitio/gincache v0.0.1-rc7/go.mod h1:IUKPDIlTSH8bNqpgMDWjgrbbkqhApnQHSxXp5uKjGg8=
-github.com/splitio/go-split-commons/v4 v4.0.4-rc2 h1:I1h3KqnAq4xTs2ld7iGZ6/aED7In83WQIU7n2LcF7vQ=
-github.com/splitio/go-split-commons/v4 v4.0.4-rc2/go.mod h1:42zur2Zsz0Y6aQ3r5Zmqkhq6/vlNF56B9BXW+QpIEeo=
+github.com/splitio/go-split-commons/v4 v4.0.4 h1:Rfyei7i7yzSJwf5vghe/2NwI4rkng+nhEaVvJecHNtc=
+github.com/splitio/go-split-commons/v4 v4.0.4/go.mod h1:42zur2Zsz0Y6aQ3r5Zmqkhq6/vlNF56B9BXW+QpIEeo=
 github.com/splitio/go-toolkit/v5 v5.0.3 h1:3LrhJo76ZYTsi/cWS2pDfH6+ImKlOqtp3J98qm4WGpY=
 github.com/splitio/go-toolkit/v5 v5.0.3/go.mod h1:K5jrJhC1A5N+JMjPUhMUhxkHExqfDbxLzhGhcZ0Ofd0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/splitio/commitversion.go
+++ b/splitio/commitversion.go
@@ -5,4 +5,4 @@ This file is created automatically, please do not edit
 */
 
 // CommitVersion is the version of the last commit previous to release
-const CommitVersion = "3c1e28c"
+const CommitVersion = "74d2c95"

--- a/splitio/commitversion.go
+++ b/splitio/commitversion.go
@@ -5,4 +5,4 @@ This file is created automatically, please do not edit
 */
 
 // CommitVersion is the version of the last commit previous to release
-const CommitVersion = "74d2c95"
+const CommitVersion = "dfdf476"

--- a/splitio/commitversion.go
+++ b/splitio/commitversion.go
@@ -5,4 +5,4 @@ This file is created automatically, please do not edit
 */
 
 // CommitVersion is the version of the last commit previous to release
-const CommitVersion = "eb1abc1"
+const CommitVersion = "3c1e28c"

--- a/splitio/commitversion.go
+++ b/splitio/commitversion.go
@@ -5,4 +5,4 @@ This file is created automatically, please do not edit
 */
 
 // CommitVersion is the version of the last commit previous to release
-const CommitVersion = "7f631f4"
+const CommitVersion = "eb1abc1"

--- a/splitio/producer/storage/telemetry.go
+++ b/splitio/producer/storage/telemetry.go
@@ -266,8 +266,7 @@ func fetchConfigsGreedy(rclient *redis.PrefixedRedisClient, limit int64) ([]dtos
 	}
 
 	if len(fromHash) == 0 && len(fromList) == 0 {
-		// TODO(mredolatti): check and return error correctly
-		return nil, true, nil
+		return nil, true, formatTelemetryFetchErrors(errors)
 	}
 
 	toRet := make([]dtos.TelemetryQueueObject, 0, len(fromHash)+len(fromList))

--- a/splitio/proxy/storage/telemetry.go
+++ b/splitio/proxy/storage/telemetry.go
@@ -333,11 +333,8 @@ type ProxyEndpointTelemetry interface {
 // ProxyTelemetryFacade defines the set of methods required to accept local telemetry as well as runtime telemetry
 type ProxyTelemetryFacade interface {
 	storage.TelemetryStorage
+	storage.TelemetryPeeker
 	ProxyEndpointTelemetry
-}
-
-type EndpointStatusCodeProducer interface {
-	IncrEndpointStatus(endpoint int, status int)
 }
 
 // ProxyTelemetryFacadeImpl exposes local telemetry functionality
@@ -360,3 +357,4 @@ func NewProxyTelemetryFacade() *ProxyTelemetryFacadeImpl {
 // Ensure interface compliance
 var _ ProxyTelemetryFacade = (*ProxyTelemetryFacadeImpl)(nil)
 var _ storage.TelemetryStorage = (*ProxyTelemetryFacadeImpl)(nil)
+var _ storage.TelemetryPeeker = (*ProxyTelemetryFacadeImpl)(nil)

--- a/splitio/proxy/storage/telemetryts.go
+++ b/splitio/proxy/storage/telemetryts.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/splitio/go-split-commons/v4/storage"
 	"github.com/splitio/go-split-commons/v4/storage/inmemory"
 )
 
@@ -18,7 +19,7 @@ const (
 // TimeslicedProxyEndpointTelemetry is a proxy telemetry facade (yet another) that bundles global data
 // and historic data by timeslice (for observability purposes)
 type TimeslicedProxyEndpointTelemetry interface {
-	ProxyEndpointTelemetry
+	ProxyTelemetryFacade
 	TimeslicedReport() TimeSliceData
 }
 
@@ -193,3 +194,5 @@ type sysClock struct{}
 func (c *sysClock) Now() time.Time { return time.Now() }
 
 var _ TimeslicedProxyEndpointTelemetry = (*TimeslicedProxyEndpointTelemetryImpl)(nil)
+var _ ProxyTelemetryPeeker = (*TimeslicedProxyEndpointTelemetryImpl)(nil)
+var _ storage.TelemetryPeeker = (*TimeslicedProxyEndpointTelemetryImpl)(nil)

--- a/splitio/version.go
+++ b/splitio/version.go
@@ -2,4 +2,4 @@
 package splitio
 
 // Version is the version of this Agent
-const Version = "5.0.4-rc1"
+const Version = "5.0.4"

--- a/splitio/version.go
+++ b/splitio/version.go
@@ -2,4 +2,4 @@
 package splitio
 
 // Version is the version of this Agent
-const Version = "5.0.3"
+const Version = "5.0.4"

--- a/splitio/version.go
+++ b/splitio/version.go
@@ -2,4 +2,4 @@
 package splitio
 
 // Version is the version of this Agent
-const Version = "5.0.4"
+const Version = "5.0.4-rc1"


### PR DESCRIPTION
Replaced telemetry interface with a broader one, tu ensure embedded structs methods are properly exposed