### PR TITLE
New: Add -ldflags external link to support Dynatrace monitoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,11 +40,11 @@ build: split-sync split-proxy
 
 ## Build the split-sync executable
 split-sync: $(sources) go.sum
-	$(GO) build -o $@ cmd/synchronizer/main.go
+	$(GO) build -ldflags '-linkmode external' -o $@ cmd/synchronizer/main.go
 
 ## Build the split-proxy executable
 split-proxy: $(sources) go.sum
-	$(GO) build -o $@ cmd/proxy/main.go
+	$(GO) build -ldflags '-linkmode external' -o $@ cmd/proxy/main.go
 
 ## Run the unit tests
 test: $(sources) go.sum


### PR DESCRIPTION
# Split Synchronizer

## What did you accomplish?
Added an additional build flag to support process monitoring in Dynatrace. Their guidance is shown here: https://www.dynatrace.com/support/help/technology-support/application-software/go/support/go-known-limitations#support-for-musl-libc

## How do we test the changes introduced in this PR?
- Regression testing to existing experience
- Engage with a trusted client who uses Dynatrace to ensure and confirm the monitoring works (Rocket Mortgage)

## Extra Notes
I have tested this locally within my enterprise and confirmed that the changes behave as intended.