### PR TITLE
Docker base images out of date

### DIFF
--- a/docker/Dockerfile.proxy
+++ b/docker/Dockerfile.proxy
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.19.3-alpine3.16 AS builder
+FROM golang:1.19.6-alpine3.16 AS builder
 
 ARG EXTRA_BUILD_ARGS
 
@@ -16,7 +16,7 @@ COPY . .
 RUN make clean split-proxy entrypoints EXTRA_BUILD_ARGS="${EXTRA_BUILD_ARGS}"
 
 # Runner stage
-FROM alpine:3.16.3 AS runner
+FROM alpine:3.16.4 AS runner
 
 RUN apk add bash
 

--- a/docker/Dockerfile.synchronizer
+++ b/docker/Dockerfile.synchronizer
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.19.3-alpine3.16 AS builder
+FROM golang:1.19.6-alpine3.16 AS builder
 
 ARG EXTRA_BUILD_ARGS
 
@@ -16,7 +16,7 @@ COPY . .
 RUN make clean split-sync entrypoints EXTRA_BUILD_ARGS="${EXTRA_BUILD_ARGS}"
 
 # Runner stage
-FROM alpine:3.16.3 AS runner
+FROM alpine:3.16.4 AS runner
 
 RUN apk add bash
 


### PR DESCRIPTION
The docker base images used by the synchronizer are out of date, update to supported alpine and golang version

# Split Synchronizer
No changes

## What did you accomplish?
Update alpine image to a supported released version

## How do we test the changes introduced in this PR?
Executed docker build, via `make images_release`

## Extra Notes
This change cannot be opened agains the `development` branch since the docker directory is not available there.
