### PR TITLE
Produce distroless minimized container images

### DIFF
--- a/docker/Dockerfile.proxy
+++ b/docker/Dockerfile.proxy
@@ -26,8 +26,8 @@ RUN bash -c 'if [[ "${FIPS_MODE}" = "enabled" ]]; \
     else echo "building in standard mode"; make clean split-proxy entrypoints EXTRA_BUILD_ARGS="${EXTRA_BUILD_ARGS}"; \
     fi'
 
-# copy1 stage
-FROM scratch AS copy1
+# distroless stage
+FROM scratch AS distroless
 
 COPY docker/functions.sh .
 
@@ -41,6 +41,8 @@ COPY --from=builder /etc/group /etc/group
 # because split-sync is dynamically linked to glibc for the net library
 COPY --from=builder /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
 COPY --from=builder /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+# health check
+COPY --from=builder /code/healthcheck.sh /usr/bin/
 # Get copyright statements for included components for legal compliance
 COPY --from=builder /usr/share/doc/ca-certificates/copyright /usr/share/doc/ca-certificates/copyright
 COPY --from=builder /usr/share/doc/bash-static/copyright /usr/share/doc/bash-static/copyright
@@ -49,7 +51,7 @@ COPY --from=builder /usr/share/doc/libc6/copyright /usr/share/doc/libc6/copyrigh
 # runner stage squashed minimum layer
 FROM scratch
 
-COPY --from=copy1 / /
+COPY --from=distroless / /
 
 EXPOSE 3000 3010
 

--- a/docker/Dockerfile.proxy
+++ b/docker/Dockerfile.proxy
@@ -5,7 +5,7 @@ ARG EXTRA_BUILD_ARGS
 ARG FIPS_MODE
 
 RUN apt update -y
-RUN apt install -y build-essential ca-certificates python3 git bash-static
+RUN apt install -y build-essential ca-certificates python3 git
 
 RUN addgroup --gid 1000 --system 'split-proxy'
 RUN adduser \
@@ -33,7 +33,7 @@ COPY docker/functions.sh .
 
 COPY --from=builder /code/split-proxy /usr/bin/
 COPY --from=builder /code/entrypoint.proxy.sh .
-COPY --from=builder /bin/bash-static /bin/bash
+COPY --from=builder /bin/bash /bin/
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/shadow /etc/shadow
@@ -41,12 +41,14 @@ COPY --from=builder /etc/group /etc/group
 # because split-sync is dynamically linked to glibc for the net library
 COPY --from=builder /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
 COPY --from=builder /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=builder /lib/x86_64-linux-gnu/libtinfo* /lib/x86_64-linux-gnu/
 # health check
 COPY --from=builder /code/healthcheck.sh /usr/bin/
 # Get copyright statements for included components for legal compliance
 COPY --from=builder /usr/share/doc/ca-certificates/copyright /usr/share/doc/ca-certificates/copyright
-COPY --from=builder /usr/share/doc/bash-static/copyright /usr/share/doc/bash-static/copyright
+COPY --from=builder /usr/share/doc/bash/copyright /usr/share/doc/bash/copyright
 COPY --from=builder /usr/share/doc/libc6/copyright /usr/share/doc/libc6/copyright
+COPY --from=builder /usr/share/doc/libtinfo6/copyright /usr/share/doc/libtinfo6/copyright
 
 # runner stage squashed minimum layer
 FROM scratch

--- a/docker/Dockerfile.proxy
+++ b/docker/Dockerfile.proxy
@@ -5,22 +5,8 @@ ARG EXTRA_BUILD_ARGS
 ARG FIPS_MODE
 
 RUN apt update -y
-RUN apt install -y build-essential ca-certificates python3 git
+RUN apt install -y build-essential ca-certificates python3 git bash-static
 
-WORKDIR /code
-
-COPY . .
-
-RUN bash -c 'if [[ "${FIPS_MODE}" = "enabled" ]]; \
-    then echo "building in fips mode"; make clean split-proxy-fips entrypoints EXTRA_BUILD_ARGS="${EXTRA_BUILD_ARGS}"; mv split-proxy-fips split-proxy; \
-    else echo "building in standard mode"; make clean split-proxy entrypoints EXTRA_BUILD_ARGS="${EXTRA_BUILD_ARGS}"; \
-    fi'
-
-# Runner stage
-FROM debian:12.10 AS runner
-
-RUN apt update -y
-RUN apt install -y bash ca-certificates
 RUN addgroup --gid 1000 --system 'split-proxy'
 RUN adduser \
     --disabled-password \
@@ -31,10 +17,39 @@ RUN adduser \
     --uid 1000 \
     'split-proxy'
 
+WORKDIR /code
+
+COPY . .
+
+RUN bash -c 'if [[ "${FIPS_MODE}" = "enabled" ]]; \
+    then echo "building in fips mode"; make clean split-proxy-fips entrypoints EXTRA_BUILD_ARGS="${EXTRA_BUILD_ARGS}"; mv split-proxy-fips split-proxy; \
+    else echo "building in standard mode"; make clean split-proxy entrypoints EXTRA_BUILD_ARGS="${EXTRA_BUILD_ARGS}"; \
+    fi'
+
+# copy1 stage
+FROM scratch AS copy1
+
 COPY docker/functions.sh .
 
 COPY --from=builder /code/split-proxy /usr/bin/
 COPY --from=builder /code/entrypoint.proxy.sh .
+COPY --from=builder /bin/bash-static /bin/bash
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/shadow /etc/shadow
+COPY --from=builder /etc/group /etc/group
+# because split-sync is dynamically linked to glibc for the net library
+COPY --from=builder /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=builder /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+# Get copyright statements for included components for legal compliance
+COPY --from=builder /usr/share/doc/ca-certificates/copyright /usr/share/doc/ca-certificates/copyright
+COPY --from=builder /usr/share/doc/bash-static/copyright /usr/share/doc/bash-static/copyright
+COPY --from=builder /usr/share/doc/libc6/copyright /usr/share/doc/libc6/copyright
+
+# runner stage squashed minimum layer
+FROM scratch
+
+COPY --from=copy1 / /
 
 EXPOSE 3000 3010
 

--- a/docker/Dockerfile.synchronizer
+++ b/docker/Dockerfile.synchronizer
@@ -26,8 +26,8 @@ RUN bash -c 'if [[ "${FIPS_MODE}" = "enabled" ]]; \
     else echo "building in standard mode"; make clean split-sync entrypoints EXTRA_BUILD_ARGS="${EXTRA_BUILD_ARGS}"; \
     fi'
 
-# copy1 stage
-FROM scratch AS copy1
+# distroless stage
+FROM scratch AS distroless
 
 COPY docker/functions.sh .
 
@@ -41,6 +41,8 @@ COPY --from=builder /etc/group /etc/group
 # because split-sync is dynamically linked to glibc for the net library
 COPY --from=builder /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
 COPY --from=builder /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+# health check
+COPY --from=builder /code/healthcheck.sh /usr/bin/
 # Get copyright statements for included components for legal compliance
 COPY --from=builder /usr/share/doc/ca-certificates/copyright /usr/share/doc/ca-certificates/copyright
 COPY --from=builder /usr/share/doc/bash-static/copyright /usr/share/doc/bash-static/copyright
@@ -50,7 +52,7 @@ COPY --from=builder /usr/share/doc/libc6/copyright /usr/share/doc/libc6/copyrigh
 # runner stage squashed minimum layer
 FROM scratch
 
-COPY --from=copy1 / /
+COPY --from=distroless / /
 
 EXPOSE 3000 3010
 

--- a/docker/Dockerfile.synchronizer
+++ b/docker/Dockerfile.synchronizer
@@ -5,7 +5,7 @@ ARG EXTRA_BUILD_ARGS
 ARG FIPS_MODE
 
 RUN apt update -y
-RUN apt install -y build-essential ca-certificates python3 git bash-static
+RUN apt install -y build-essential ca-certificates python3 git
 
 RUN addgroup --gid 1000 --system 'split-synchronizer'
 RUN adduser \
@@ -33,7 +33,7 @@ COPY docker/functions.sh .
 
 COPY --from=builder /code/split-sync /usr/bin/
 COPY --from=builder /code/entrypoint.synchronizer.sh .
-COPY --from=builder /bin/bash-static /bin/bash
+COPY --from=builder /bin/bash /bin/
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/shadow /etc/shadow
@@ -41,12 +41,14 @@ COPY --from=builder /etc/group /etc/group
 # because split-sync is dynamically linked to glibc for the net library
 COPY --from=builder /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
 COPY --from=builder /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=builder /lib/x86_64-linux-gnu/libtinfo* /lib/x86_64-linux-gnu/
 # health check
 COPY --from=builder /code/healthcheck.sh /usr/bin/
 # Get copyright statements for included components for legal compliance
 COPY --from=builder /usr/share/doc/ca-certificates/copyright /usr/share/doc/ca-certificates/copyright
-COPY --from=builder /usr/share/doc/bash-static/copyright /usr/share/doc/bash-static/copyright
+COPY --from=builder /usr/share/doc/bash/copyright /usr/share/doc/bash/copyright
 COPY --from=builder /usr/share/doc/libc6/copyright /usr/share/doc/libc6/copyright
+COPY --from=builder /usr/share/doc/libtinfo6/copyright /usr/share/doc/libtinfo6/copyright
 
 
 # runner stage squashed minimum layer

--- a/docker/Dockerfile.synchronizer
+++ b/docker/Dockerfile.synchronizer
@@ -5,22 +5,8 @@ ARG EXTRA_BUILD_ARGS
 ARG FIPS_MODE
 
 RUN apt update -y
-RUN apt install -y build-essential ca-certificates python3 git
+RUN apt install -y build-essential ca-certificates python3 git bash-static
 
-WORKDIR /code
-
-COPY . .
-
-RUN bash -c 'if [[ "${FIPS_MODE}" = "enabled" ]]; \
-    then echo "building in fips mode"; make clean split-sync-fips entrypoints EXTRA_BUILD_ARGS="${EXTRA_BUILD_ARGS}"; mv split-sync-fips split-sync; \
-    else echo "building in standard mode"; make clean split-sync entrypoints EXTRA_BUILD_ARGS="${EXTRA_BUILD_ARGS}"; \
-    fi'
-
-# Runner stage
-FROM debian:12.10 AS runner
-
-RUN apt update -y
-RUN apt install -y bash ca-certificates
 RUN addgroup --gid 1000 --system 'split-synchronizer'
 RUN adduser \
     --disabled-password \
@@ -31,10 +17,40 @@ RUN adduser \
     --uid 1000 \
     'split-synchronizer'
 
+WORKDIR /code
+
+COPY . .
+
+RUN bash -c 'if [[ "${FIPS_MODE}" = "enabled" ]]; \
+    then echo "building in fips mode"; make clean split-sync-fips entrypoints EXTRA_BUILD_ARGS="${EXTRA_BUILD_ARGS}"; mv split-sync-fips split-sync; \
+    else echo "building in standard mode"; make clean split-sync entrypoints EXTRA_BUILD_ARGS="${EXTRA_BUILD_ARGS}"; \
+    fi'
+
+# copy1 stage
+FROM scratch AS copy1
+
 COPY docker/functions.sh .
 
 COPY --from=builder /code/split-sync /usr/bin/
 COPY --from=builder /code/entrypoint.synchronizer.sh .
+COPY --from=builder /bin/bash-static /bin/bash
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/shadow /etc/shadow
+COPY --from=builder /etc/group /etc/group
+# because split-sync is dynamically linked to glibc for the net library
+COPY --from=builder /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=builder /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+# Get copyright statements for included components for legal compliance
+COPY --from=builder /usr/share/doc/ca-certificates/copyright /usr/share/doc/ca-certificates/copyright
+COPY --from=builder /usr/share/doc/bash-static/copyright /usr/share/doc/bash-static/copyright
+COPY --from=builder /usr/share/doc/libc6/copyright /usr/share/doc/libc6/copyright
+
+
+# runner stage squashed minimum layer
+FROM scratch
+
+COPY --from=copy1 / /
 
 EXPOSE 3000 3010
 

--- a/docker/entrypoint.sh.tpl
+++ b/docker/entrypoint.sh.tpl
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 FLAGS=({{ARGS}})
 

--- a/docker/functions.sh
+++ b/docker/functions.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 function parse_flags_from_conf_file() {
     fn=$1
@@ -21,7 +21,8 @@ function flag_to_env_var() {
         return 1
     fi
 
-    echo "${prefix}_${flag}" | tr "[a-z]" "[A-Z]" | tr "-" "_"
+    uppercase="${prefix^^}_${flag^^}"
+    echo "${uppercase//-/_}"
     return 0
 }
 

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+HOSTNAME="localhost"
+PORT=3010
+
+rc=1
+lineno=0
+exec 5<> /dev/tcp/${HOSTNAME}/${PORT}
+printf "GET /health/application HTTP/1.1\r\nHost: ${HOSTNAME}\r\nConnection: close\r\n\r\n" >&5
+while read LINE <&5; do
+    if [[ $lineno -eq 0 && ${LINE} =~ HTTP/1.1[[:space:]]200[[:space:]]OK ]]; then
+	rc=0
+    fi
+    lineno=$((lineno+1))
+done
+
+exit $rc


### PR DESCRIPTION
In support of feature request https://github.com/splitio/split-synchronizer/issues/311

This change produces a minimal container image (~25MB) containing only the entrypoint bash executable, the split-sync or split-proxy executable, and the minimal Debian files needed for these to execute.

The dependency on the `tr` application was removed from functions.sh by using bash variable parameter expansion instead.

split-sync and split-proxy are dynamically linked with libc because the go net library requires it.  Therefore, libc is copied into the final image too.  bash needs libtinfo6 so we include that.

ca-certificates are copied into the image so TLS connections to split.io can be validated.

A healthcheck.sh script is added for use by container runtimes such as AWS ECS, which avoids needing to include curl or wget in the image - bash can do it for us.

The last build stage is used to produce a single-layer final container.