### PR TITLE
Add streaming-force-http1 config to pin the streaming connection to HTTP/1.1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+5.13.0 (Aug 19, 2026)
+- Added streaming-force-http1 option (CLI flag -streaming-force-http1, config key streamingForceHttp1, default false) to pin the streaming (SSE) connection to HTTP/1.1.
+
 5.12.8 (Aug 6, 2026)
 - Fixed vulnerabilities:
    - Updated golang builder image to 1.26.5-trixie, resolving CVE-2026-42504, CVE-2026-42507, CVE-2026-27145

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/gin-gonic/gin v1.10.1
 	github.com/google/uuid v1.3.0
 	github.com/splitio/gincache v1.0.1
-	github.com/splitio/go-split-commons/v10 v10.0.0
-	github.com/splitio/go-toolkit/v5 v5.4.1
+	github.com/splitio/go-split-commons/v10 v10.1.0
+	github.com/splitio/go-toolkit/v5 v5.5.0
 	github.com/stretchr/testify v1.11.1
 	go.etcd.io/bbolt v1.3.6
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d

--- a/go.sum
+++ b/go.sum
@@ -74,10 +74,10 @@ github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUA
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/splitio/gincache v1.0.1 h1:dLYdANY/BqH4KcUMCe/LluLyV5WtuE/LEdQWRE06IXU=
 github.com/splitio/gincache v1.0.1/go.mod h1:CcgJDSM9Af75kyBH0724v55URVwMBuSj5x1eCWIOECY=
-github.com/splitio/go-split-commons/v10 v10.0.0 h1:W2j9OJaghOzX9hI7hlrregLygAjF//JghY8VNvZEw3k=
-github.com/splitio/go-split-commons/v10 v10.0.0/go.mod h1:/gEHK8JR4FudvLcAYp4gaMMejmzt1NKhap/0lIhjkIw=
-github.com/splitio/go-toolkit/v5 v5.4.1 h1:srTyvDBJZMUcJ/KiiQDMyjCuELVgTBh2TGRVn0sOXEE=
-github.com/splitio/go-toolkit/v5 v5.4.1/go.mod h1:SifzysrOVDbzMcOE8zjX02+FG5az4FrR3Us/i5SeStw=
+github.com/splitio/go-split-commons/v10 v10.1.0 h1:mB1yOiC/hG3KU9rkn4iQdgLLnM/pute7Lg/RD6HEi6s=
+github.com/splitio/go-split-commons/v10 v10.1.0/go.mod h1:IyvyjqD91g6ba1uWnC3Ww/o5c/Xt31swlVT1g3+jmGw=
+github.com/splitio/go-toolkit/v5 v5.5.0 h1:+Dn3WxAL9If88F3E0HVLHHc+Vkci9CQPIq4vlqhqE8E=
+github.com/splitio/go-toolkit/v5 v5.5.0/go.mod h1:SifzysrOVDbzMcOE8zjX02+FG5az4FrR3Us/i5SeStw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/splitio/producer/conf/sections.go
+++ b/splitio/producer/conf/sections.go
@@ -26,6 +26,7 @@ func (m *Main) BuildAdvancedConfig() *cconf.AdvancedConfig {
 	tmp := conf.InitAdvancedOptions(false) // defaults + url overrides
 	tmp.HTTPTimeout = int(m.Sync.Advanced.HTTPTimeoutMs / 1000)
 	tmp.StreamingEnabled = m.Sync.Advanced.StreamingEnabled
+	tmp.StreamingForceHTTP1 = m.Sync.Advanced.StreamingForceHTTP1
 	tmp.SplitsRefreshRate = int(m.Sync.SplitRefreshRateMs / 1000)
 	tmp.SegmentsRefreshRate = int(m.Sync.SegmentRefreshRateMs / 1000)
 	return tmp
@@ -56,6 +57,7 @@ type Sync struct {
 // AdvancedSync configuration options
 type AdvancedSync struct {
 	StreamingEnabled                 bool  `json:"streamingEnabled" s-cli:"streaming-enabled" s-def:"true" s-desc:"Enable/disable streaming functionality"`
+	StreamingForceHTTP1              bool  `json:"streamingForceHttp1" s-cli:"streaming-force-http1" s-def:"false" s-desc:"Pin the streaming (SSE) connection to HTTP/1.1 (default is HTTP/2)"`
 	HTTPTimeoutMs                    int64 `json:"httpTimeoutMs" s-cli:"http-timeout-ms" s-def:"30000" s-desc:"Total http request timeout"`
 	InternalMetricsRateMs            int64 `json:"internalTelemetryRateMs" s-cli:"internal-metrics-rate-ms" s-def:"3600000" s-desc:"How often to send internal metrics"`
 	TelemetryPushRateMs              int64 `json:"telemetryPushRateMs" s-cli:"telemetry-push-rate-ms" s-def:"60000" s-desc:"how often to flush sdk telemetry"`

--- a/splitio/proxy/conf/sections.go
+++ b/splitio/proxy/conf/sections.go
@@ -32,6 +32,7 @@ func (m *Main) BuildAdvancedConfig() *cconf.AdvancedConfig {
 	tmp.ImpressionsQueueSize = int(m.Sync.Advanced.ImpressionsBuffer / 1000)
 	tmp.EventsQueueSize = int(m.Sync.Advanced.EventsBuffer)
 	tmp.StreamingEnabled = m.Sync.Advanced.StreamingEnabled
+	tmp.StreamingForceHTTP1 = m.Sync.Advanced.StreamingForceHTTP1
 	tmp.SplitsRefreshRate = int(m.Sync.SplitRefreshRateMs / 1000)
 	tmp.SegmentsRefreshRate = int(m.Sync.SegmentRefreshRateMs / 1000)
 	tmp.LargeSegment.LazyLoad = m.Sync.Advanced.LargeSegmentLazyLoad
@@ -82,6 +83,7 @@ type Sync struct {
 // AdvancedSync configuration options
 type AdvancedSync struct {
 	StreamingEnabled      bool  `json:"streamingEnabled" s-cli:"streaming-enabled" s-def:"true" s-desc:"Enable/disable streaming functionality"`
+	StreamingForceHTTP1   bool  `json:"streamingForceHttp1" s-cli:"streaming-force-http1" s-def:"false" s-desc:"Pin the streaming (SSE) connection to HTTP/1.1 (default is HTTP/2)"`
 	HTTPTimeoutMs         int64 `json:"httpTimeoutMs" s-cli:"http-timeout-ms" s-def:"30000" s-desc:"Total http request timeout"`
 	ImpressionsBuffer     int64 `json:"impressionsBufferSize" s-cli:"impressions-buffer-size" s-def:"500" s-dec:"How many impressions bulks to keep in memory"`
 	EventsBuffer          int64 `json:"eventsBufferSize" s-cli:"events-buffer-size" s-def:"500" s-dec:"How many events bulks to keep in memory"`

--- a/splitio/version.go
+++ b/splitio/version.go
@@ -2,4 +2,4 @@
 package splitio
 
 // Version is the version of this Agent
-const Version = "5.12.8"
+const Version = "5.13.0"


### PR DESCRIPTION
**What**
Exposes a new streaming-force-http1 option (CLI flag -streaming-force-http1, config-file key streamingForceHttp1, default false) on both the synchronizer and proxy. It maps to AdvancedConfig.StreamingForceHTTP1 in go-split-commons v10.1.0, which pins the streaming (SSE) connection to HTTP/1.1.

**Why**
The streaming connection is a single long-lived stream where HTTP/2 provides no benefit, and Go's http2 client stack emits noisy protocol error: received DATA after END_STREAM logs. This gives operators an opt-in escape hatch to silence that noise. Default is unchanged (HTTP/2).

**Changes**
- splitio/producer/conf/sections.go, splitio/proxy/conf/sections.go: new StreamingForceHTTP1 field + mapping into the commons advanced config.
- go.mod/go.sum: bump go-split-commons to v10.1.0, go-toolkit to v5.5.0.

**Depends on**
go-split-commons v10.1.0 and go-toolkit v5.5.0 (both tagged and public).