### PR TITLE
log the configured streaming (SSE) protocol at startup

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,5 @@
 5.13.0 (Aug 19, 2026)
 - Added streaming-force-http1 option (CLI flag -streaming-force-http1, config key streamingForceHttp1, default false) to pin the streaming (SSE) connection to HTTP/1.1.
-
-5.12.8 (Aug 6, 2026)
 - Fixed vulnerabilities:
    - Updated golang builder image to 1.26.5-trixie, resolving CVE-2026-42504, CVE-2026-42507, CVE-2026-27145
 

--- a/splitio/common/streaming.go
+++ b/splitio/common/streaming.go
@@ -1,0 +1,19 @@
+package common
+
+import "github.com/splitio/go-toolkit/v5/logging"
+
+// LogStreamingProtocol emits an info line describing which HTTP protocol the
+// streaming (SSE) connection is configured to use. It reflects the configured
+// intent (the streaming-force-http1 flag), not the protocol negotiated on the
+// wire. When streaming is disabled there is no SSE connection, so nothing is
+// logged.
+func LogStreamingProtocol(logger logging.LoggerInterface, streamingEnabled bool, forceHTTP1 bool) {
+	if !streamingEnabled {
+		return
+	}
+	if forceHTTP1 {
+		logger.Info("Streaming (SSE) connection configured to use HTTP/1.1")
+		return
+	}
+	logger.Info("Streaming (SSE) connection configured to use HTTP/2")
+}

--- a/splitio/common/streaming.go
+++ b/splitio/common/streaming.go
@@ -2,18 +2,10 @@ package common
 
 import "github.com/splitio/go-toolkit/v5/logging"
 
-// LogStreamingProtocol emits an info line describing which HTTP protocol the
-// streaming (SSE) connection is configured to use. It reflects the configured
-// intent (the streaming-force-http1 flag), not the protocol negotiated on the
-// wire. When streaming is disabled there is no SSE connection, so nothing is
-// logged.
-func LogStreamingProtocol(logger logging.LoggerInterface, streamingEnabled bool, forceHTTP1 bool) {
-	if !streamingEnabled {
-		return
+// LogStreamingForceHTTP1 logs an info line when the streaming (SSE) connection
+// is pinned to HTTP/1.1 via the streaming-force-http1 setting.
+func LogStreamingForceHTTP1(logger logging.LoggerInterface, streamingEnabled bool, forceHTTP1 bool) {
+	if streamingEnabled && forceHTTP1 {
+		logger.Info("Streaming (SSE) connection forced to HTTP/1.1")
 	}
-	if forceHTTP1 {
-		logger.Info("Streaming (SSE) connection configured to use HTTP/1.1")
-		return
-	}
-	logger.Info("Streaming (SSE) connection configured to use HTTP/2")
 }

--- a/splitio/producer/initialization.go
+++ b/splitio/producer/initialization.go
@@ -51,6 +51,7 @@ func Start(logger logging.LoggerInterface, cfg *conf.Main) error {
 	advanced.AuthSpecVersion = cfg.FlagSpecVersion
 	advanced.FlagsSpecVersion = cfg.FlagSpecVersion
 	advanced.FlagSetsFilter = cfg.FlagSetsFilter
+	common.LogStreamingProtocol(logger, advanced.StreamingEnabled, advanced.StreamingForceHTTP1)
 	metadata := util.GetMetadata(false, cfg.IPAddressEnabled)
 
 	clientKey, err := util.GetClientKey(cfg.Apikey)

--- a/splitio/producer/initialization.go
+++ b/splitio/producer/initialization.go
@@ -51,7 +51,7 @@ func Start(logger logging.LoggerInterface, cfg *conf.Main) error {
 	advanced.AuthSpecVersion = cfg.FlagSpecVersion
 	advanced.FlagsSpecVersion = cfg.FlagSpecVersion
 	advanced.FlagSetsFilter = cfg.FlagSetsFilter
-	common.LogStreamingProtocol(logger, advanced.StreamingEnabled, advanced.StreamingForceHTTP1)
+	common.LogStreamingForceHTTP1(logger, advanced.StreamingEnabled, advanced.StreamingForceHTTP1)
 	metadata := util.GetMetadata(false, cfg.IPAddressEnabled)
 
 	clientKey, err := util.GetClientKey(cfg.Apikey)

--- a/splitio/proxy/initialization.go
+++ b/splitio/proxy/initialization.go
@@ -82,7 +82,7 @@ func Start(logger logging.LoggerInterface, cfg *pconf.Main) error {
 	advanced.FlagSetsFilter = cfg.FlagSetsFilter
 	advanced.AuthSpecVersion = cfg.FlagSpecVersion
 	advanced.FlagsSpecVersion = cfg.FlagSpecVersion
-	common.LogStreamingProtocol(logger, advanced.StreamingEnabled, advanced.StreamingForceHTTP1)
+	common.LogStreamingForceHTTP1(logger, advanced.StreamingEnabled, advanced.StreamingForceHTTP1)
 	metadata := util.GetMetadata(cfg.IPAddressEnabled, true)
 
 	// FlagSetsFilter

--- a/splitio/proxy/initialization.go
+++ b/splitio/proxy/initialization.go
@@ -82,6 +82,7 @@ func Start(logger logging.LoggerInterface, cfg *pconf.Main) error {
 	advanced.FlagSetsFilter = cfg.FlagSetsFilter
 	advanced.AuthSpecVersion = cfg.FlagSpecVersion
 	advanced.FlagsSpecVersion = cfg.FlagSpecVersion
+	common.LogStreamingProtocol(logger, advanced.StreamingEnabled, advanced.StreamingForceHTTP1)
 	metadata := util.GetMetadata(cfg.IPAddressEnabled, true)
 
 	// FlagSetsFilter


### PR DESCRIPTION
 Adds an info log at synchronizer and proxy startup stating whether the streaming (SSE) connection is configured for HTTP/1.1 or HTTP/2, based on the streaming-force-http1 setting. Extracted into a shared common.LogStreamingProtocol helper used by both entrypoints.